### PR TITLE
Adds example/sample* files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+example/sample*


### PR DESCRIPTION
I remembered that we discussed adding the "example/sample*" (source, min, max) to gitignore for development
