### PR TITLE
handle LF on windows and tweak the tests to make them pass on win32

### DIFF
--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -14,6 +14,9 @@ exports.namespace = require('../util/namespace');
 // An external utility, exposed.
 exports.hooker = require('hooker');
 
+// The line feed char for the current system
+exports.linefeed = process.platform === 'win32' ? '\r\n' : '\n';
+
 // What "kind" is a value?
 // I really need to rework https://github.com/cowboy/javascript-getclass
 var kindsOf = {};

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -7,8 +7,6 @@
  * http://benalman.com/about/license/
  */
 
-var lf = process.platform === 'win32' ? '\r\n' : '\n';
-
 // ============================================================================
 // TASKS
 // ============================================================================
@@ -33,5 +31,5 @@ task.registerBasicTask('concat', 'Concatenate files.', function(data, name) {
 task.registerHelper('concat', function(files) {
   return files ? files.map(function(filepath) {
     return task.directive(filepath, file.read);
-  }).join(lf) : '';
+  }).join(util.linefeed) : '';
 });

--- a/tasks/misc.js
+++ b/tasks/misc.js
@@ -9,8 +9,6 @@
 
 var spawn = require('child_process').spawn;
 
-var lf = process.platform === 'win32' ? '\r\n' : '\n';
-
 // ============================================================================
 // HELPERS
 // ============================================================================
@@ -60,7 +58,7 @@ task.registerHelper('banner', function(prop) {
     verbose.write('Generating banner...');
     try {
       // Compile and run template, passing in config object as the data source.
-      banner = template.process(tmpl, obj) + lf;
+      banner = template.process(tmpl, obj) + util.linefeed;
       verbose.ok();
     } catch(e) {
       banner = '';

--- a/test/tasks/concat_test.js
+++ b/test/tasks/concat_test.js
@@ -1,4 +1,4 @@
-var lf = process.platform === 'win32' ? '\r\n' : '\n';
+var lf = util.linefeed;
 
 exports['concat'] = function(test) {
   test.expect(1);

--- a/test/tasks/misc_test.js
+++ b/test/tasks/misc_test.js
@@ -1,4 +1,4 @@
-var lf = process.platform === 'win32' ? '\r\n' : '\n';
+var lf = util.linefeed;
 
 exports['config'] = function(test) {
   test.expect(2);
@@ -53,7 +53,7 @@ exports['file_strip_banner'] = function(test) {
   var filepath = 'test/fixtures/banner.js';
   test.equal(task.helper('file_strip_banner', filepath), '// Comment' + lf + '' + lf + '/* Comment */' + lf + '', 'It should strip only the top banner.');
   filepath = 'test/fixtures/banner2.js';
-  test.equal(task.helper('file_strip_banner', filepath), '' + lf + '/*! SAMPLE' + lf + ' * BANNER */' + lf + '' + lf + '// Comment' + lf + '' + lf + '/* Comment */' + lf + '', 'It should not strip a top banner beginning with /*!.');
+  test.equal(task.helper('file_strip_banner', filepath), '' + lf + '/*! SAMPLE' + lf + ' * BANNER */' + lf + lf + '// Comment' + lf + '' + lf + '/* Comment */' + lf + '', 'It should not strip a top banner beginning with /*!.');
   test.done();
 };
 


### PR DESCRIPTION
related to #34

I had to make some tiny changes in order to make tests pass on windows.

Both the concat / misc task files have been slightly edited, mainly tweaking some helpers and the related concat / misc tests.

I hope that's ok, it's not a critical issue but is a bit annoying when running the tests or implementing new ones when developping specifically on windows :)
