### PR TITLE
default init task to plugin name, Closes GH-76

### DIFF
--- a/tasks/init.js
+++ b/tasks/init.js
@@ -44,8 +44,8 @@ module.exports = function(grunt) {
   grunt.registerInitTask('init', 'Generate project scaffolding from a predefined template.', function() {
     // Extra arguments will be applied to the template file.
     var args = utils.toArray(arguments);
-    // Template name.
-    var name = args.shift();
+    // Template name. Default to plugin name if omitted.
+    var name = args.shift() || grunt._npmTask;
     // Valid init templates (.js files).
     var templates = {};
     task.expandFiles('init/*.js').forEach(function(fileobj) {


### PR DESCRIPTION
this appears sufficient for defaulting the init task to a plugin name.
