### PR TITLE
Fix 'target' -> 'this.target' in all instances of multiTask docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -160,8 +160,8 @@ grunt.initConfig({
   }
 });
 
-grunt.registerMultiTask('log', 'Log stuff.', function(target) {
-  grunt.log.writeln(target + ': ' + this.data);
+grunt.registerMultiTask('log', 'Log stuff.', function() {
+  grunt.log.writeln(this.target + ': ' + this.data);
 });
 ```
 

--- a/docs/api_task.md
+++ b/docs/api_task.md
@@ -80,8 +80,8 @@ grunt.initConfig({
   }
 });
 
-grunt.task.registerMultiTask('log', 'Log stuff.', function(target) {
-  grunt.log.writeln(target + ': ' + this.data);
+grunt.task.registerMultiTask('log', 'Log stuff.', function() {
+  grunt.log.writeln(this.target + ': ' + this.data);
 });
 ```
 

--- a/docs/types_of_tasks.md
+++ b/docs/types_of_tasks.md
@@ -60,8 +60,8 @@ config.init({
   }
 });
 
-task.registerMultiTask('logstuff', 'This task logs stuff.', function(target) {
-  // target === the name of the target
+task.registerMultiTask('logstuff', 'This task logs stuff.', function() {
+  // this.target === the name of the target
   // this.data === the target's value in the config object
   // this.name === the task name
   // this.args === an array of args specified after the target on the command-line
@@ -69,7 +69,7 @@ task.registerMultiTask('logstuff', 'This task logs stuff.', function(target) {
   // this.file === file-specific .src and .dest properties
 
   // Log some stuff.
-  log.writeln(target + ': ' + this.data);
+  log.writeln(this.target + ': ' + this.data);
 
   // If data was falsy, abort!!
   if (!this.data) { return false; }


### PR DESCRIPTION
The following is wrong, AFAIK. `target` is never passed in the arguments, you must access it via `this.target`. I might be wrong, but I tried explicitly targeting and just running all targets and `this.target` was the only thing that worked for me.

``` js
/*global config:true, task:true*/
config.init({
  logstuff: {
    foo: [1, 2, 3],
    bar: 'hello world',
    baz: false
  }
});

task.registerMultiTask('logstuff', 'This task logs stuff.', function(target) {
  // target === the name of the target
  // this.data === the target's value in the config object
  // this.name === the task name
  // this.args === an array of args specified after the target on the command-line
  // this.flags === a map of flags specified after the target on the command-line
  // this.file === file-specific .src and .dest properties

  // Log some stuff.
  log.writeln(target + ': ' + this.data);

  // If data was falsy, abort!!
  if (!this.data) { return false; }
  log.writeln('Logging stuff succeeded.');
});
```

Fixed:

``` js
task.registerMultiTask('logstuff', 'This task logs stuff.', function() {
  // this.target === the name of the target
  // this.data === the target's value in the config object
  // this.name === the task name
  // this.args === an array of args specified after the target on the command-line
  // this.flags === a map of flags specified after the target on the command-line
  // this.file === file-specific .src and .dest properties

  // Log some stuff.
  log.writeln(this.target + ': ' + this.data);

  // If data was falsy, abort!!
  if (!this.data) { return false; }
  log.writeln('Logging stuff succeeded.');
});
```
