### PR TITLE
Support for writing gruntfiles and tasks in CoffeeScript

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -151,6 +151,9 @@ function loadTask(filepath) {
   var fn;
   try {
     // Load taskfile.
+    if (filepath.match(/\.coffee$/)) {
+    	require('coffee-script');
+    }
     fn = require(path.resolve(filepath));
     if (typeof fn === 'function') {
       fn.call(grunt, grunt);
@@ -186,7 +189,7 @@ function loadTasks(tasksdir) {
   try {
     fs.readdirSync(tasksdir).filter(function(filename) {
       // Filter out non-.js files.
-      return path.extname(filename).toLowerCase() === '.js';
+      return path.extname(filename).toLowerCase() === '.js' || path.extname(filename).toLowerCase() === '.coffee';
     }).forEach(function(filename) {
       // Load task.
       loadTask(path.join(tasksdir, filename));
@@ -347,7 +350,8 @@ task.init = function(tasks, options) {
   // Get any local configfile or tasks that might exist. Use --config override
   // if specified, otherwise search the current directory or any parent.
   var configfile = allInit ? null : grunt.option('config') ||
-    grunt.file.findup(process.cwd(), 'grunt.js');
+    grunt.file.findup(process.cwd(), 'grunt.js') ||
+    grunt.file.findup(process.cwd(), 'grunt.coffee');
 
   var msg = 'Reading "' + path.basename(configfile) + '" config file...';
   if (configfile && path.existsSync(configfile)) {


### PR DESCRIPTION
Guaranteed to start a flamewar, perhaps?

In all seriousness, this doesn't introduce any actual dependency, and if you never personally write any CoffeeScript, this change really has no effect at all.
