### PR TITLE
User Template Delimiters (ref #123)

### DIFF
--- a/lib/grunt/template.js
+++ b/lib/grunt/template.js
@@ -41,6 +41,16 @@ template.delimiters = function(mode) {
       evaluate:     /\{%([\s\S]+?)%\}/g,
       interpolate:  /\{%=([\s\S]+?)%\}/g,
       escape:       /\{%-([\s\S]+?)%\}/g
+    },
+    // In rare occasions user delimiters [] are used in templates and explicitly
+    // handled in specific task implementations.
+    user: {
+      // Used by grunt.
+      opener:       '[%',
+      // Used by underscore.
+      evaluate:     /\[%([\s\S]+?)%\]/g,
+      interpolate:  /\[%=([\s\S]+?)%\]/g,
+      escape:       /\[%-([\s\S]+?)%\]/g
     }
   };
   var settings = modes[mode in modes ? mode : 'default'];

--- a/test/grunt/template_test.js
+++ b/test/grunt/template_test.js
@@ -16,5 +16,44 @@ exports['template'] = {
     obj.foo = '<% oops %';
     test.equal(grunt.template.process('<%= baz %>', obj), 'ab<% oops %de', 'should not explode.');
     test.done();
+  },
+  
+  'init mode': function(test) {
+    test.expect(5);
+    var obj = {
+      foo: 'c',
+      bar: 'b{%= foo %}d',
+      baz: 'a{%= bar %}e'
+    };
+
+    test.equal(grunt.template.process('{%= foo %}', obj, 'init'), 'c', 'should retrieve value.');
+    test.equal(grunt.template.process('{%= bar %}', obj, 'init'), 'bcd', 'should recurse.');
+    test.equal(grunt.template.process('{%= baz %}', obj, 'init'), 'abcde', 'should recurse.');
+    
+    test.equal(grunt.template.process('{%= foo %}<%= foo %>', obj, 'init'), 'c<%= foo %>', 'should ignore default delimiters');
+
+    obj.foo = '{% oops %';
+    test.equal(grunt.template.process('{%= baz %}', obj, 'init'), 'ab{% oops %de', 'should not explode.');
+    
+    test.done();
+  },
+  
+  'user mode': function(test) {
+    test.expect(5);
+    var obj = {
+      foo: 'c',
+      bar: 'b[%= foo %]d',
+      baz: 'a[%= bar %]e'
+    };
+
+    test.equal(grunt.template.process('[%= foo %]', obj, 'user'), 'c', 'should retrieve value.');
+    test.equal(grunt.template.process('[%= bar %]', obj, 'user'), 'bcd', 'should recurse.');
+    test.equal(grunt.template.process('[%= baz %]', obj, 'user'), 'abcde', 'should recurse.');
+    
+    test.equal(grunt.template.process('[%= foo %]<%= foo %>', obj, 'user'), 'c<%= foo %>', 'should ignore default delimiters');
+
+    obj.foo = '[% oops %';
+    test.equal(grunt.template.process('[%= baz %]', obj, 'user'), 'ab[% oops %de', 'should not explode.');
+    test.done();
   }
 };


### PR DESCRIPTION
Works perfectly - thanks for the pointers.  I'll keep working on the wrapper plugin using the `[% %]` delimiters.
