### PR TITLE
Missing a comma in the example of getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     lint: {
-      all: ['grunt.js', 'lib/**/*.js''test/**/*.js']
+      all: ['grunt.js', 'lib/**/*.js', 'test/**/*.js']
     },
     jshint: {
       options: {


### PR DESCRIPTION
Just a minor correction in the sample code.
