### PR TITLE
Use growl notification to notify user if grunt produces an error (if node-growl is installed)

### DIFF
--- a/lib/grunt/log.js
+++ b/lib/grunt/log.js
@@ -24,9 +24,11 @@ log.muted = false;
 // True once anything has actually been logged.
 var hasLogged;
 
-// Use growl for notifications
-var growl = require("growl");
-
+//Try and load growl
+try{
+  var growl = require("growl");
+}catch(e){
+}
 // Parse certain markup in strings to be logged.
 function markup(str) {
   str = str || '';
@@ -61,16 +63,18 @@ log.writeln = function(msg) {
 log.error = function(msg) {
   if (msg) {
     grunt.fail.errorcount++;
-    growl(msg, {
-      title: "Grunt Error",
-      image: "/usr/share/icons/gnome/48x48/status/dialog-error.png"
-    });
+    if(typeof(growl) != "undefined"){
+      growl(msg, {
+        title: "Grunt Error",
+      });
+    }
     return this.writeln('>> '.red + grunt.utils._.trim(msg).replace(/\n/g, '\n>> '.red));
   } else {
-    growl("ERROR", {
-      title: "Grunt Error",
-      image: "/usr/share/icons/gnome/48x48/status/dialog-error.png"
-    });
+    if(typeof(growl) != "undefined"){
+      growl("ERROR", {
+        title: "Grunt Error",
+      });
+    }
     return this.writeln('ERROR'.red);
   }
 };


### PR DESCRIPTION
In response to issue #48

Use growl notification to notify user if grunt produces an error (if node-growl is installed)
