### PR TITLE
Allow JSHint 0.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dateformat": "1.0.2-1.2.3",
     "glob-whatev": "~0.1.6",
     "hooker": "~0.2.3",
-    "jshint": "~0.6.3",
+    "jshint": "~0.7.1",
     "nodeunit": "~0.7.4",
     "nopt": "~1.0.10",
     "prompt": "~0.1.12",


### PR DESCRIPTION
This is a small update to the package.json to allow 0.7.x releases of JSHint to be used.
