### PR TITLE
Configure Phantomjs/Qunit test timeout value

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -197,6 +197,8 @@ module.exports = function(grunt) {
           grunt.task.getFile('qunit/qunit.js'),
           // URL to the QUnit .html test file to run.
           url,
+          // The test timeout value (innactivity)
+          ( grunt.config.get('phantomjs') || {} ).timeout || 5000,
           // PhantomJS options.
           '--config=' + grunt.task.getFile('qunit/phantom.json')
         ],

--- a/tasks/qunit/phantom.js
+++ b/tasks/qunit/phantom.js
@@ -17,6 +17,8 @@ var tmpfile = phantom.args[0];
 var qunit = phantom.args[1];
 // The QUnit .html test file to run.
 var url = phantom.args[2];
+// The timeout for each qunit test
+var timeout = phantom.args[3];
 
 // Keep track of the last time a QUnit message was sent.
 var last = new Date();
@@ -38,7 +40,7 @@ function sendDebugMessage() {
 
 // Abort if QUnit doesn't do anything for a while.
 setInterval(function() {
-  if (new Date() - last > 5000) {
+  if (new Date() - last > timeout) {
     sendMessage(['done_timeout']);
   }
 }, 1000);


### PR DESCRIPTION
This pull request allows for configuring the phantomjs timeout value on individual qunit tests. Example config:

``` javascript
grunt.initConfig({
  qunit: {
    all: ['foo/*']
  },

  phantomjs: {
    timeout: 10000
  }
});
```

The pr is mostly a proof of concept for a couple reasons:
1. It would be nice to put the timeout value in the qunit config but I believe multitasks assume config options are file globs? (not at all sure here)
2. It's reasonable to expect the value to be set in seconds and not miliseconds.
3. Getting the config value out of the global config at the point of the command line for the phantom helper is a bit janky. Also I'm not sure how you set defaults internally.

Anyway, we need this for some longer running tests in the jqm test suite. I'm happy to help and change this as necessary. Also I understand completely if this isn't something you want to bother with!

Thanks.
