### PR TITLE
Enable strict mode

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // Project configuration.
@@ -43,8 +45,7 @@ module.exports = function(grunt) {
         boss: true,
         eqnull: true,
         node: true,
-        es5: true,
-        strict: false
+        es5: true
       },
       globals: {}
     }

--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // Nodejs libs.
 var path = require('path');
 

--- a/lib/grunt/cli.js
+++ b/lib/grunt/cli.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 var grunt = require('../grunt');
 
 // Nodejs libs.

--- a/lib/grunt/config.js
+++ b/lib/grunt/config.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 var grunt = require('../grunt');
 
 // The actual config data.

--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 var grunt = require('../grunt');
 
 // The module to be exported.

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 var grunt = require('../grunt');
 
 // Nodejs libs.

--- a/lib/grunt/help.js
+++ b/lib/grunt/help.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 var grunt = require('../grunt');
 
 // Nodejs libs.

--- a/lib/grunt/log.js
+++ b/lib/grunt/log.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 var grunt = require('../grunt');
 
 // Nodejs libs.

--- a/lib/grunt/option.js
+++ b/lib/grunt/option.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // The actual option data.
 var data = {};
 

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 var grunt = require('../grunt');
 
 // Nodejs libs.

--- a/lib/grunt/template.js
+++ b/lib/grunt/template.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 var grunt = require('../grunt');
 
 // The module to be exported.

--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // Nodejs libs.
 var spawn = require('child_process').spawn;
 var nodeUtil = require('util');

--- a/lib/util/findup.js
+++ b/lib/util/findup.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // Nodejs libs.
 var path = require('path');
 

--- a/lib/util/namespace.js
+++ b/lib/util/namespace.js
@@ -9,6 +9,8 @@
 
 (function(exports) {
 
+  'use strict';
+
   // Split strings on dot, but only if dot isn't preceded by a backslash. Since
   // JavaScript doesn't support lookbehinds, use a placeholder for "\.", split
   // on dot, then replace the placeholder character with a dot.

--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -9,6 +9,8 @@
 
 (function(exports) {
 
+  'use strict';
+
   // Construct-o-rama.
   function Task() {
     // Information about the currently-running task.

--- a/tasks/concat.js
+++ b/tasks/concat.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // ==========================================================================

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // Nodejs libs.

--- a/tasks/init/commonjs.js
+++ b/tasks/init/commonjs.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // Basic template description.
 exports.description = 'Create a commonjs module, including Nodeunit unit tests.';
 

--- a/tasks/init/gruntfile.js
+++ b/tasks/init/gruntfile.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // Basic template description.
 exports.description = 'Create a basic Gruntfile.';
 

--- a/tasks/init/gruntplugin.js
+++ b/tasks/init/gruntplugin.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // Basic template description.
 exports.description = 'Create a grunt plugin, including Nodeunit unit tests.';
 

--- a/tasks/init/jquery.js
+++ b/tasks/init/jquery.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // Basic template description.
 exports.description = 'Create a jQuery plugin, including QUnit unit tests.';
 

--- a/tasks/init/node.js
+++ b/tasks/init/node.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 // Basic template description.
 exports.description = 'Create a Node.js module, including Nodeunit unit tests.';
 

--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // External libs.

--- a/tasks/min.js
+++ b/tasks/min.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // External libs.

--- a/tasks/misc.js
+++ b/tasks/misc.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // ==========================================================================

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // Nodejs libs.

--- a/tasks/qunit/phantom.js
+++ b/tasks/qunit/phantom.js
@@ -9,6 +9,8 @@
 
 /*global phantom:true*/
 
+'use strict';
+
 var fs = require('fs');
 
 // The temporary file used for communications.

--- a/tasks/qunit/qunit.js
+++ b/tasks/qunit/qunit.js
@@ -9,6 +9,8 @@
 
 /*global QUnit:true, alert:true*/
 
+'use strict';
+
 // Don't re-order tests.
 QUnit.config.reorder = false;
 // Run tests serially, not in parallel.

--- a/tasks/server.js
+++ b/tasks/server.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // Nodejs libs.

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // Nodejs libs.

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -7,6 +7,8 @@
  * http://benalman.com/about/license/
  */
 
+'use strict';
+
 module.exports = function(grunt) {
 
   // Nodejs libs.

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var grunt = require('../../lib/grunt');
 
 var fs = require('fs');

--- a/test/grunt/template_test.js
+++ b/test/grunt/template_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var grunt = require('../../lib/grunt');
 
 exports['template'] = {

--- a/test/grunt/util_test.js
+++ b/test/grunt/util_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var grunt = require('../../lib/grunt');
 
 exports['utils.callbackify'] = {

--- a/test/tasks/concat_test.js
+++ b/test/tasks/concat_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var grunt = require('../../lib/grunt');
 
 // In case the grunt being used to test is different than the grunt being

--- a/test/tasks/init_test.js
+++ b/test/tasks/init_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var grunt = require('../../lib/grunt');
 
 // In case the grunt being used to test is different than the grunt being

--- a/test/tasks/lint_test.js
+++ b/test/tasks/lint_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var grunt = require('../../lib/grunt');
 
 // In case the grunt being used to test is different than the grunt being

--- a/test/tasks/misc_test.js
+++ b/test/tasks/misc_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var grunt = require('../../lib/grunt');
 
 // In case the grunt being used to test is different than the grunt being

--- a/test/util/namespace_test.js
+++ b/test/util/namespace_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var namespace = require('../../lib/util/namespace.js');
 
 exports.get = {

--- a/test/util/task_test.js
+++ b/test/util/task_test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Test helpers.
 function delay(fn) { setTimeout(fn, 10); }
 
@@ -13,7 +15,7 @@ var result = (function() {
   };
 }());
 
-var requireTask = require.bind(this, '../../lib/util/task.js');
+var requireTask = require.bind(exports, '../../lib/util/task.js');
 
 exports['new Task'] = {
   'create': function(test) {


### PR DESCRIPTION
Closes #179.
Linted with grunt ;)

Although when `'use strict';` is outside the closure on `lib/util/namespace.js` and `lib/util/task.js` I get a `Possible strict violation` because of the `exports || this` lines. Just let me know if you prefer the strict statement outside the close and to change `exports || this` to just `exports`.
