### PR TITLE
Migration for deprecated path.existsSync

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 // Nodejs lib.
+var fs = require('fs');
 var path = require('path');
+var existsSync = fs.existsSync || path.existsSync;
 
 // Badass internal grunt lib.
 var findup = require('../lib/util/findup');
@@ -14,7 +16,7 @@ if (!gruntfile) { gruntfile = findup(process.cwd(), 'grunt.js'); }
 // Where might a locally-installed grunt live?
 var dir = path.resolve(gruntfile, '../node_modules/grunt');
 // If grunt is installed locally, use it. Otherwise use this grunt.
-if (!path.existsSync(dir)) { dir = '../lib/grunt'; }
+if (!existsSync(dir)) { dir = '../lib/grunt'; }
 
 // Run grunt.
 require(dir).cli();

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -14,6 +14,7 @@ var grunt = require('../grunt');
 // Nodejs libs.
 var fs = require('fs');
 var path = require('path');
+var existsSync = fs.existsSync || path.existsSync;
 
 // The module to be exported.
 var file = module.exports = {};
@@ -176,7 +177,7 @@ file.mkdir = function(dirpath) {
   dirpath.split(/[\/\\]/).reduce(function(parts, part) {
     parts += part + '/';
     var subpath = path.resolve(parts);
-    if (!path.existsSync(subpath)) {
+    if (!file.exists(subpath)) {
       try {
         fs.mkdirSync(subpath, '0755');
       } catch(e) {
@@ -298,13 +299,13 @@ file.userDir = function() {
   var win32 = process.platform === 'win32';
   var homepath = process.env[win32 ? 'USERPROFILE' : 'HOME'];
   dirpath = path.resolve(homepath, '.grunt', dirpath);
-  return path.existsSync(dirpath) ? dirpath : null;
+  return file.exists(dirpath) ? dirpath : null;
 };
 
 // True if the file path exists.
 file.exists = function() {
   var filepath = path.join.apply(path, arguments);
-  return path.existsSync(filepath);
+  return existsSync(filepath);
 };
 
 // True if the file is a symbolic link.

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -294,7 +294,7 @@ task.readDefaults = function() {
     filepaths = task.searchDirs.map(function(dirpath) {
       return path.join(dirpath, filepath);
     }).filter(function(filepath) {
-      return path.existsSync(filepath) && fs.statSync(filepath).isFile();
+      return grunt.file.exists(filepath) && fs.statSync(filepath).isFile();
     });
     // Load defaults data.
     if (filepaths.length) {
@@ -312,7 +312,7 @@ task.readDefaults = function() {
 // Load tasks and handlers from a given directory.
 task.loadTasks = function(tasksdir) {
   loadTasksMessage('"' + tasksdir + '"');
-  if (path.existsSync(tasksdir)) {
+  if (grunt.file.exists(tasksdir)) {
     task.searchDirs.unshift(tasksdir);
     loadTasks(tasksdir);
   } else {
@@ -325,7 +325,7 @@ task.loadTasks = function(tasksdir) {
 task.loadNpmTasks = function(name) {
   loadTasksMessage('"' + name + '" local Npm module');
   var tasksdir = path.resolve('node_modules', name, 'tasks');
-  if (path.existsSync(tasksdir)) {
+  if (grunt.file.exists(tasksdir)) {
     task.searchDirs.unshift(tasksdir);
     loadTasks(tasksdir);
   } else {
@@ -341,7 +341,7 @@ function loadNpmTasksWithRequire(name) {
   try {
     dirpath = require.resolve(name);
     dirpath = path.resolve(path.join(path.dirname(dirpath), 'tasks'));
-    if (path.existsSync(dirpath)) {
+    if (grunt.file.exists(dirpath)) {
       task.searchDirs.unshift(dirpath);
       loadTasks(dirpath);
       return;
@@ -377,7 +377,7 @@ task.init = function(tasks, options) {
     grunt.file.findup(process.cwd(), '{G,g}runtfile.{js,coffee}');
 
   var msg = 'Reading "' + path.basename(gruntfile) + '" Gruntfile...';
-  if (gruntfile && path.existsSync(gruntfile)) {
+  if (gruntfile && grunt.file.exists(gruntfile)) {
     grunt.verbose.writeln().write(msg).ok();
     // Change working directory so that all paths are relative to the
     // Gruntfile's location (or the --base option, if specified).

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -13,7 +13,6 @@ module.exports = function(grunt) {
 
   // Nodejs libs.
   var fs = require('fs');
-  var path = require('path');
 
   // ==========================================================================
   // TASKS
@@ -122,7 +121,7 @@ module.exports = function(grunt) {
         watchedFiles[filepath] = fs.watch(filepath, function(event) {
           var mtime;
           // Has the file been deleted?
-          var deleted = !path.existsSync(filepath);
+          var deleted = !grunt.file.exists(filepath);
           if (deleted) {
             // If file was deleted, stop watching file.
             unWatchFile(filepath);

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -255,8 +255,9 @@ exports['file'] = {
     test.done();
   },
   'exists': function(test) {
-    test.expect(4);
+    test.expect(5);
     test.ok(grunt.file.exists('test/fixtures/octocat.png'), 'should return true');
+    test.ok(grunt.file.exists('test', 'fixtures', 'octocat.png'), 'should return true');
     test.ok(grunt.file.exists('test/fixtures/octocat-link.png'), 'should return true');
     test.ok(grunt.file.exists('test/fixtures'), 'should return true');
     test.equal(grunt.file.exists('test/fixtures/does/not/exist'), false, 'should return false');


### PR DESCRIPTION
`path.existsSync` is deprecated in v0.8. This PR provides a migration for it. Thanks!
