### PR TITLE
Allow deprecation notice to be nerfed

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -47,7 +47,8 @@ Object.defineProperty(grunt, 'utils', {
       grunt.fail.errorcount--;
     }
     return util;
-  }
+  },
+  configurable: true
 });
 
 // Expose some grunt metadata.


### PR DESCRIPTION
I'm working with Grunt 0.4.0 and a lot of the grunt plugins I'm pulling in from npm still use `grunt.utils` so I hit the deprecation notice a lot. 

I have PRs going out to the existing projects but still my hands are tied to some degree.

Can we make this guy configurable so I can quiet the warning at will?

:heart:
