### PR TITLE
Remove grunt as a dependency from the package.json generated by init:gruntplugin

### DIFF
--- a/tasks/init/gruntplugin.js
+++ b/tasks/init/gruntplugin.js
@@ -45,7 +45,7 @@ exports.template = function(grunt, init, done) {
     props.main = 'Gruntfile.js';
     props.npm_test = 'grunt test';
     props.bin = 'bin/' + props.name;
-    props.dependencies = {grunt: props.grunt_version};
+    props.dependencies = {};
     props.keywords = ['gruntplugin'];
 
     // Files to copy (and process).


### PR DESCRIPTION
If you run `grunt init:gruntplugin`, the generated package.json will list grunt as a dependency. Unless I'm missing something, this seems unnecessary as most tasks don't actually depend on grunt. Tasks usually interact with the `grunt` object passed to `module.exports`, but rarely require it.
