### PR TITLE
Fix lint errors with init templates

### DIFF
--- a/tasks/init/commonjs/root/Gruntfile.js
+++ b/tasks/init/commonjs/root/Gruntfile.js
@@ -1,4 +1,5 @@
 module.exports = function(grunt) {
+  'use strict';
 
   // Project configuration.
   grunt.initConfig({

--- a/tasks/init/commonjs/root/lib/name.js
+++ b/tasks/init/commonjs/root/lib/name.js
@@ -7,6 +7,7 @@
  */
 
 (function(exports) {
+  'use strict';
 
   exports.awesome = function() {
     return 'awesome';

--- a/tasks/init/commonjs/root/test/name_test.js
+++ b/tasks/init/commonjs/root/test/name_test.js
@@ -1,4 +1,7 @@
-/*global require:true */
+/*global require:true, exports:true*/
+/*jshint globalstrict:true, sub:true*/
+'use strict';
+
 var {%= js_safe_name %} = require('../lib/{%= name %}.js');
 
 /*

--- a/tasks/init/gruntplugin/root/Gruntfile.js
+++ b/tasks/init/gruntplugin/root/Gruntfile.js
@@ -1,6 +1,5 @@
-'use strict';
-
 module.exports = function(grunt) {
+  'use strict';
 
   // Project configuration.
   grunt.initConfig({

--- a/tasks/init/gruntplugin/root/tasks/name.js
+++ b/tasks/init/gruntplugin/root/tasks/name.js
@@ -6,9 +6,8 @@
  * Licensed under the {%= licenses.join(', ') %} license{%= licenses.length === 1 ? '' : 's' %}.
  */
 
-'use strict';
-
 module.exports = function(grunt) {
+  'use strict';
 
   // Please see the grunt documentation for more information regarding task and
   // helper creation: https://github.com/cowboy/grunt/blob/master/docs/toc.md

--- a/tasks/init/gruntplugin/root/test/name_test.js
+++ b/tasks/init/gruntplugin/root/test/name_test.js
@@ -1,3 +1,5 @@
+/*global require:true, exports:true*/
+/*jshint globalstrict:true, sub:true*/
 'use strict';
 
 var grunt = require('grunt');

--- a/tasks/init/node/root/Gruntfile.js
+++ b/tasks/init/node/root/Gruntfile.js
@@ -1,6 +1,5 @@
-'use strict';
-
 module.exports = function(grunt) {
+  'use strict';
 
   // Project configuration.
   grunt.initConfig({

--- a/tasks/init/node/root/lib/name.js
+++ b/tasks/init/node/root/lib/name.js
@@ -6,8 +6,8 @@
  * Licensed under the {%= licenses.join(', ') %} license{%= licenses.length === 1 ? '' : 's' %}.
  */
 
-'use strict';
-
 exports.awesome = function() {
+  'use strict';
+
   return 'awesome';
 };

--- a/tasks/init/node/root/test/name_test.js
+++ b/tasks/init/node/root/test/name_test.js
@@ -1,3 +1,5 @@
+/*global require:true, exports:true*/
+/*jshint globalstrict:true, sub:true*/
 'use strict';
 
 var {%= js_safe_name %} = require('../lib/{%= name %}.js');


### PR DESCRIPTION
This PR fixes lint errors when generating projects with `init`.

Some of the lint errors were:

```
[L1:C1] Use the function form of "use strict".
'use strict';
[L3:C13] 'require' is not defined.
var grunt = require('grunt');
[L25:C1] 'exports' is not defined.
exports['test'] = {
[L25:C9] ['test'] is better written in dot notation.
exports['test'] = {
```

Tested all by `sudo npm link` on this branch. Created an empty folder and ran `grunt init:[template]`, `grunt`, `rm -rf *`... repeat. All are lint free with this PR.
