### PR TITLE
Use new options in init templates

### DIFF
--- a/tasks/init/commonjs/root/Gruntfile.js
+++ b/tasks/init/commonjs/root/Gruntfile.js
@@ -24,31 +24,30 @@ module.exports = function(grunt) {
       files: ['test/**/*.js']
     },
     lint: {
-      files: ['Gruntfile.js', 'lib/**/*.js', 'test/**/*.js']
+      files: ['Gruntfile.js', 'lib/**/*.js', 'test/**/*.js'],
+      options: {
+        options: {
+          curly: true,
+          eqeqeq: true,
+          immed: true,
+          latedef: true,
+          newcap: true,
+          noarg: true,
+          sub: true,
+          undef: true,
+          boss: true,
+          eqnull: true
+        },
+        globals: {
+          exports: true,
+          module: false
+        }
+      }
     },
     watch: {
       files: '<config:lint.files>',
       tasks: 'lint test'
-    },
-    jshint: {
-      options: {
-        curly: true,
-        eqeqeq: true,
-        immed: true,
-        latedef: true,
-        newcap: true,
-        noarg: true,
-        sub: true,
-        undef: true,
-        boss: true,
-        eqnull: true
-      },
-      globals: {
-        exports: true,
-        module: false
-      }
-    },
-    uglify: {}
+    }
   });
 
   // Default task.

--- a/tasks/init/gruntplugin/root/Gruntfile.js
+++ b/tasks/init/gruntplugin/root/Gruntfile.js
@@ -8,28 +8,28 @@ module.exports = function(grunt) {
       files: ['test/**/*.js']
     },
     lint: {
-      files: ['Gruntfile.js', 'tasks/**/*.js', 'test/**/*.js']
+      files: ['Gruntfile.js', 'tasks/**/*.js', 'test/**/*.js'],
+      options: {
+        options: {
+          curly: true,
+          eqeqeq: true,
+          immed: true,
+          latedef: true,
+          newcap: true,
+          noarg: true,
+          sub: true,
+          undef: true,
+          boss: true,
+          eqnull: true,
+          node: true,
+          es5: true
+        },
+        globals: {}
+      }
     },
     watch: {
       files: '<config:lint.files>',
       tasks: 'default'
-    },
-    jshint: {
-      options: {
-        curly: true,
-        eqeqeq: true,
-        immed: true,
-        latedef: true,
-        newcap: true,
-        noarg: true,
-        sub: true,
-        undef: true,
-        boss: true,
-        eqnull: true,
-        node: true,
-        es5: true
-      },
-      globals: {}
     }
   });
 

--- a/tasks/init/jquery/root/Gruntfile.js
+++ b/tasks/init/jquery/root/Gruntfile.js
@@ -25,31 +25,30 @@ module.exports = function(grunt) {
       files: ['test/**/*.html']
     },
     lint: {
-      files: ['Gruntfile.js', 'src/**/*.js', 'test/**/*.js']
+      files: ['Gruntfile.js', 'src/**/*.js', 'test/**/*.js'],
+      options: {
+        options: {
+          curly: true,
+          eqeqeq: true,
+          immed: true,
+          latedef: true,
+          newcap: true,
+          noarg: true,
+          sub: true,
+          undef: true,
+          boss: true,
+          eqnull: true,
+          browser: true
+        },
+        globals: {
+          jQuery: true
+        }
+      }
     },
     watch: {
       files: '<config:lint.files>',
       tasks: 'lint qunit'
-    },
-    jshint: {
-      options: {
-        curly: true,
-        eqeqeq: true,
-        immed: true,
-        latedef: true,
-        newcap: true,
-        noarg: true,
-        sub: true,
-        undef: true,
-        boss: true,
-        eqnull: true,
-        browser: true
-      },
-      globals: {
-        jQuery: true
-      }
-    },
-    uglify: {}
+    }
   });
 
   // Default task.

--- a/tasks/init/node/root/Gruntfile.js
+++ b/tasks/init/node/root/Gruntfile.js
@@ -9,29 +9,29 @@ module.exports = function(grunt) {
       files: ['test/**/*.js']
     },
     lint: {
-      files: ['Gruntfile.js', 'lib/**/*.js', 'test/**/*.js']
+      files: ['Gruntfile.js', 'lib/**/*.js', 'test/**/*.js'],
+      options: {
+        options: {
+          curly: true,
+          eqeqeq: true,
+          immed: true,
+          latedef: true,
+          newcap: true,
+          noarg: true,
+          sub: true,
+          undef: true,
+          boss: true,
+          eqnull: true,
+          node: true
+        },
+        globals: {
+          exports: true
+        }
+      }
     },
     watch: {
       files: '<config:lint.files>',
       tasks: 'default'
-    },
-    jshint: {
-      options: {
-        curly: true,
-        eqeqeq: true,
-        immed: true,
-        latedef: true,
-        newcap: true,
-        noarg: true,
-        sub: true,
-        undef: true,
-        boss: true,
-        eqnull: true,
-        node: true
-      },
-      globals: {
-        exports: true
-      }
     }
   });
 


### PR DESCRIPTION
Moved jshint to lint.options in the templates. Tested and grunted each one. Lint free. Thanks!
