### PR TITLE
Gentrify min task to allow the helper used to be specified per target

### DIFF
--- a/tasks/min.js
+++ b/tasks/min.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
   // TASKS
   // ==========================================================================
 
-  grunt.registerMultiTask('min', 'Minify files with UglifyJS.', function() {
+  grunt.registerMultiTask('min', 'Minify files.', function() {
     var files = grunt.file.expandFiles(this.file.src);
     // Get banner, if specified. It would be nice if UglifyJS supported ignoring
     // all comments matching a certain pattern, like /*!...*/, but it doesn't.
@@ -49,8 +49,10 @@ module.exports = function(grunt) {
       done();
     }
 
+    var helper = this.data.helper || 'uglify';
+
     var that = this;
-    grunt.helper('uglify', max, grunt.config('uglify'), function(code) {
+    grunt.helper(helper, max, grunt.config(helper), function(code) {
       complete.call(that, code);
     });
   });


### PR DESCRIPTION
I wanted to put up a branch with code to get feedback on an approach I've been toying with - namely, one of making the min task generic so that the helper to be used for minifying can be specified per target.

I've included two changes in the branch so far:
- make min an async task
- allow a helper property to be specified against a target and call that named helper (defaulting to uglify)

My goal here was to enable dropping in a different javascript compiler to existing grunt build files, and I wrote a module that exposes Google Closure conforming to the the same internal min helper API allowing it to be dropped in by specifying the value 'closure' as a target helper property. This required making min task/helper async internally since Closure does not immediately return.

What are your thoughts on making "standard" tasks generic as a general approach? There are a number of further refinements I have considered should the approach be pursued:
- ability to switch helper for all min targets
- pass array of input files to helper as opposed to expanded data
- support compiler specific options (including per target)
