### PR TITLE
Add minimal Ant JUnit XML reporter to qunit task

### DIFF
--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -116,7 +116,8 @@ module.exports = function(grunt) {
     };
 
     this.beginXmlElement = function (elementName, attributes) {
-      var formattedAttributes = [];
+      var formattedAttributes = [],
+        attribute;
 
       for (attribute in attributes || {}) {
         if (Object.prototype.hasOwnProperty.call(attributes, attribute)) {
@@ -146,7 +147,7 @@ module.exports = function(grunt) {
     };
 
     this.xmlCData = function (text) {
-      return '<![CDATA[' + String(text).replace(/]]>/g, ']]]]><![CDATA[>') + ']]>';
+      return '<![CDATA[' + String(text).replace(/\]\]>/g, ']]]]><![CDATA[>') + ']]>';
     };
 
     this.allDone = function (callback) {


### PR DESCRIPTION
This adds a minimal Ant JUnit-compatible XML reporter to qunit task. This works for me under TeamCity.
The reporter gets activated when antJUnitXmlReport option is specified on the task.

Please note that I'm rather new to node and Grunt internals. I'm open for suggestions on how to improve this code.

The reported may be further enriched with other additional information. I based it on the schema from here https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd. Code for original Ant reporter here: http://svn.apache.org/repos/asf/ant/core/trunk/src/main/org/apache/tools/ant/taskdefs/optional/junit/XMLJUnitResultFormatter.java.
