### PR TITLE
Adding method for unregistering already registered tasks.

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -38,6 +38,7 @@ gExpose(task, 'registerTask');
 gExpose(task, 'registerMultiTask');
 gExpose(task, 'registerInitTask');
 gExpose(task, 'renameTask');
+gExpose(task, 'unregisterTask');
 gExpose(task, 'registerHelper');
 gExpose(task, 'renameHelper');
 gExpose(task, 'helper');

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -58,6 +58,15 @@ task.registerTask = function(name, info, fn) {
   return task;
 };
 
+// Allows you to remove a task that has already been registered
+task.unregisterTask = function(name) {
+  var ti = registry.tasks.indexOf(name);
+  if (ti > -1) {
+    registry.tasks.splice(ti, 1);
+  }
+  delete task._tasks[name];
+}
+
 // This is the most common "multi task" pattern.
 task.registerMultiTask = function(name, info, fn) {
   task.registerTask(name, info, function(target) {


### PR DESCRIPTION
unregisterTask() is very helpful for removing default tasks that you don't want to use (and thus don't want to show up when you type grunt --help).
