### PR TITLE
Prevent JSHint from reporting BOM as unsafe characters.

### DIFF
--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -43,7 +43,10 @@ module.exports = function(grunt) {
 
     // Lint specified files.
     grunt.file.expandFiles(this.file.src).forEach(function(filepath) {
-      grunt.helper('lint', grunt.file.read(filepath), options, globals, filepath);
+      var src = grunt.file.read(filepath);
+      // Remove potential Unicode Byte Order Mark.
+      src = src.replace(/^\uFEFF/, '');
+      grunt.helper('lint', src, options, globals, filepath);
     });
 
     // Fail task if errors were logged.


### PR DESCRIPTION
Function grunt.file.read preserves Unicode Byte Order Mark on read
files. This is reported by JSHint as unsafe characters. This change
manually removes BOM from the source before handing it to JSHint.

This mimics similar change in node-jshint:
https://github.com/jshint/node-jshint/commit/b3fd586d7e136b16856bdb84ac2260f2250fca30
