### PR TITLE
bin/grunt: Avoid the `path.existsSync` warning

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -1,16 +1,23 @@
 #!/usr/bin/env node
 
-// Nodejs lib.
+// Nodejs libs.
+var fs = require('fs');
 var path = require('path');
+// In Nodejs 0.8.0, existsSync moved from path -> fs.
+var existsSync = fs.existsSync || path.existsSync;
 
 // Badass internal grunt lib.
 var findup = require('../lib/util/findup');
 
-// Where might a locally-installed grunt live?
-var dir = path.resolve(findup(process.cwd(), 'grunt.js'), '../node_modules/grunt');
+// Search for Gruntfile.
+var gruntfile = findup(process.cwd(), '{G,g}runtfile.{js,coffee}');
+// Gruntfile not found, look for pre-0.4.0 grunt.js file. TODO: remove, someday.
+if (!gruntfile) { gruntfile = findup(process.cwd(), 'grunt.js'); }
 
+// Where might a locally-installed grunt live?
+var dir = path.resolve(gruntfile, '../node_modules/grunt');
 // If grunt is installed locally, use it. Otherwise use this grunt.
-if (!path.existsSync(dir)) { dir = '../lib/grunt'; }
+if (!existsSync(dir)) { dir = '../lib/grunt'; }
 
 // Run grunt.
 require(dir).cli();


### PR DESCRIPTION
Ref. cowboy/grunt#241.

Untested. Basically, this updates bin/grunt to the latest version of https://github.com/cowboy/grunt/blob/devel/bin/grunt.
