### PR TITLE
Normalize linefeeds for testing on Windows

### DIFF
--- a/tasks/misc.js
+++ b/tasks/misc.js
@@ -30,5 +30,4 @@ module.exports = function(grunt) {
     }
     return jsons[filepath];
   });
-
 };


### PR DESCRIPTION
Fixes the failing tests in `misc_test` and `concat_test` on Windows.
