### PR TITLE
Get rid of path.existSync warning

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
-// Nodejs lib.
+// Nodejs libs.
+var fs = require('fs');
 var path = require('path');
+// support: node <0.8
+var existsSync = fs.existsSync || path.existsSync;
 
 // Badass internal grunt lib.
 var findup = require('../lib/util/findup');
@@ -10,7 +13,7 @@ var findup = require('../lib/util/findup');
 var dir = path.resolve(findup(process.cwd(), 'grunt.js'), '../node_modules/grunt');
 
 // If grunt is installed locally, use it. Otherwise use this grunt.
-if (!path.existsSync(dir)) { dir = '../lib/grunt'; }
+if (!existsSync(dir)) { dir = '../lib/grunt'; }
 
 // Run grunt.
 require(dir).cli();

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -12,6 +12,8 @@ var grunt = require('../grunt');
 // Nodejs libs.
 var fs = require('fs');
 var path = require('path');
+// support: node <0.8
+var existsSync = fs.existsSync || path.existsSync;
 
 // The module to be exported.
 var file = module.exports = {};
@@ -114,7 +116,7 @@ file.mkdir = function(dirpath) {
   dirpath.split(/[\/\\]/).reduce(function(parts, part) {
     parts += part + '/';
     var subpath = path.resolve(parts);
-    if (!path.existsSync(subpath)) {
+    if (!existsSync(subpath)) {
       try {
         fs.mkdirSync(subpath, '0755');
       } catch(e) {
@@ -236,5 +238,5 @@ file.userDir = function() {
   var win32 = process.platform === 'win32';
   var homepath = process.env[win32 ? 'USERPROFILE' : 'HOME'];
   dirpath = path.resolve(homepath, '.grunt', dirpath);
-  return path.existsSync(dirpath) ? dirpath : null;
+  return existsSync(dirpath) ? dirpath : null;
 };

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -12,6 +12,8 @@ var grunt = require('../grunt');
 // Nodejs libs.
 var path = require('path');
 var fs = require('fs');
+// support: node <0.8
+var existsSync = fs.existsSync || path.existsSync;
 
 // Extend generic "task" utils lib.
 var parent = grunt.utils.task.create();
@@ -267,7 +269,7 @@ task.readDefaults = function() {
     filepaths = task.searchDirs.map(function(dirpath) {
       return path.join(dirpath, filepath);
     }).filter(function(filepath) {
-      return path.existsSync(filepath) && fs.statSync(filepath).isFile();
+      return existsSync(filepath) && fs.statSync(filepath).isFile();
     });
     // Load defaults data.
     if (filepaths.length) {
@@ -285,7 +287,7 @@ task.readDefaults = function() {
 // Load tasks and handlers from a given directory.
 task.loadTasks = function(tasksdir) {
   loadTasksMessage('"' + tasksdir + '"');
-  if (path.existsSync(tasksdir)) {
+  if (existsSync(tasksdir)) {
     task.searchDirs.unshift(tasksdir);
     loadTasks(tasksdir);
   } else {
@@ -298,7 +300,7 @@ task.loadTasks = function(tasksdir) {
 task.loadNpmTasks = function(name) {
   loadTasksMessage('"' + name + '" local Npm module');
   var tasksdir = path.resolve('node_modules', name, 'tasks');
-  if (path.existsSync(tasksdir)) {
+  if (existsSync(tasksdir)) {
     task.searchDirs.unshift(tasksdir);
     loadTasks(tasksdir);
   } else {
@@ -314,7 +316,7 @@ function loadNpmTasksWithRequire(name) {
   try {
     dirpath = require.resolve(name);
     dirpath = path.resolve(path.join(path.dirname(dirpath), 'tasks'));
-    if (path.existsSync(dirpath)) {
+    if (existsSync(dirpath)) {
       task.searchDirs.unshift(dirpath);
       loadTasks(dirpath);
       return;
@@ -350,7 +352,7 @@ task.init = function(tasks, options) {
     grunt.file.findup(process.cwd(), 'grunt.js');
 
   var msg = 'Reading "' + path.basename(configfile) + '" config file...';
-  if (configfile && path.existsSync(configfile)) {
+  if (configfile && existsSync(configfile)) {
     grunt.verbose.writeln().write(msg).ok();
     // Change working directory so that all paths are relative to the
     // configfile's location (or the --base option, if specified).

--- a/lib/util/findup.js
+++ b/lib/util/findup.js
@@ -9,12 +9,15 @@
 
 // Nodejs libs.
 var path = require('path');
+var fs = require('fs');
+// support: node <0.8
+var existsSync = fs.existsSync || path.existsSync;
 
 // Search for a filename in the given directory or all parent directories.
 module.exports = function findup(dirpath, filename) {
   var filepath = path.join(dirpath, filename);
   // Return file if found.
-  if (path.existsSync(filepath)) { return filepath; }
+  if (existsSync(filepath)) { return filepath; }
   // If parentpath is the same as dirpath, we can't go any higher.
   var parentpath = path.resolve(dirpath, '..');
   return parentpath === dirpath ? null : findup(parentpath, filename);

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -12,6 +12,8 @@ module.exports = function(grunt) {
   // Nodejs libs.
   var fs = require('fs');
   var path = require('path');
+  // support: node <0.8
+  var existsSync = fs.existsSync || path.existsSync;
 
   // ==========================================================================
   // TASKS
@@ -116,7 +118,7 @@ module.exports = function(grunt) {
         watchedFiles[filepath] = fs.watch(filepath, function(event) {
           var mtime;
           // Has the file been deleted?
-          var deleted = !path.existsSync(filepath);
+          var deleted = !existsSync(filepath);
           if (deleted) {
             // If file was deleted, stop watching file.
             unWatchFile(filepath);


### PR DESCRIPTION
I know this was already fixed in `devel`, but I need this in a stable grunt release (0.3.13 plz).

In my special case, it turns out that the warning is actually interpreted as an error, causing a grunt task that calls another grunt build to fail, due to that warning and nothing else.
