### PR TITLE
Fixed typo in getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     lint: {
-      all: ['grunt.js', 'lib/**/*.js''test/**/*.js']
+      all: ['grunt.js', 'lib/**/*.js', 'test/**/*.js']
     },
     jshint: {
       options: {


### PR DESCRIPTION
A show stopper for when you just, well, get started and copy the code.
