### PR TITLE
Don't use deprecated function path.existsSync if fs.existsSync exists.

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -2,6 +2,8 @@
 
 // Nodejs lib.
 var path = require('path');
+var fs = require('fs');
+
 
 // Badass internal grunt lib.
 var findup = require('../lib/util/findup');
@@ -10,7 +12,7 @@ var findup = require('../lib/util/findup');
 var dir = path.resolve(findup(process.cwd(), 'grunt.js'), '../node_modules/grunt');
 
 // If grunt is installed locally, use it. Otherwise use this grunt.
-if (!path.existsSync(dir)) { dir = '../lib/grunt'; }
+if (!(fs.existsSync || path.existsSync)(dir)) { dir = '../lib/grunt'; }
 
 // Run grunt.
 require(dir).cli();

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -12,6 +12,7 @@ var grunt = require('../grunt');
 // Nodejs libs.
 var fs = require('fs');
 var path = require('path');
+var pathExistsSync = fs.existsSync || path.existsSync;
 
 // The module to be exported.
 var file = module.exports = {};
@@ -114,7 +115,7 @@ file.mkdir = function(dirpath) {
   dirpath.split(/[\/\\]/).reduce(function(parts, part) {
     parts += part + '/';
     var subpath = path.resolve(parts);
-    if (!path.existsSync(subpath)) {
+    if (!pathExistsSync(subpath)) {
       try {
         fs.mkdirSync(subpath, '0755');
       } catch(e) {
@@ -236,5 +237,5 @@ file.userDir = function() {
   var win32 = process.platform === 'win32';
   var homepath = process.env[win32 ? 'USERPROFILE' : 'HOME'];
   dirpath = path.resolve(homepath, '.grunt', dirpath);
-  return path.existsSync(dirpath) ? dirpath : null;
+  return pathExistsSync(dirpath) ? dirpath : null;
 };

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -12,6 +12,7 @@ var grunt = require('../grunt');
 // Nodejs libs.
 var path = require('path');
 var fs = require('fs');
+var pathExistsSync = fs.existsSync || path.existsSync;
 
 // Extend generic "task" utils lib.
 var parent = grunt.utils.task.create();
@@ -267,7 +268,7 @@ task.readDefaults = function() {
     filepaths = task.searchDirs.map(function(dirpath) {
       return path.join(dirpath, filepath);
     }).filter(function(filepath) {
-      return path.existsSync(filepath) && fs.statSync(filepath).isFile();
+      return pathExistsSync(filepath) && fs.statSync(filepath).isFile();
     });
     // Load defaults data.
     if (filepaths.length) {
@@ -285,7 +286,7 @@ task.readDefaults = function() {
 // Load tasks and handlers from a given directory.
 task.loadTasks = function(tasksdir) {
   loadTasksMessage('"' + tasksdir + '"');
-  if (path.existsSync(tasksdir)) {
+  if (pathExistsSync(tasksdir)) {
     task.searchDirs.unshift(tasksdir);
     loadTasks(tasksdir);
   } else {
@@ -298,7 +299,7 @@ task.loadTasks = function(tasksdir) {
 task.loadNpmTasks = function(name) {
   loadTasksMessage('"' + name + '" local Npm module');
   var tasksdir = path.resolve('node_modules', name, 'tasks');
-  if (path.existsSync(tasksdir)) {
+  if (pathExistsSync(tasksdir)) {
     task.searchDirs.unshift(tasksdir);
     loadTasks(tasksdir);
   } else {
@@ -314,7 +315,7 @@ function loadNpmTasksWithRequire(name) {
   try {
     dirpath = require.resolve(name);
     dirpath = path.resolve(path.join(path.dirname(dirpath), 'tasks'));
-    if (path.existsSync(dirpath)) {
+    if (pathExistsSync(dirpath)) {
       task.searchDirs.unshift(dirpath);
       loadTasks(dirpath);
       return;
@@ -350,7 +351,7 @@ task.init = function(tasks, options) {
     grunt.file.findup(process.cwd(), 'grunt.js');
 
   var msg = 'Reading "' + path.basename(configfile) + '" config file...';
-  if (configfile && path.existsSync(configfile)) {
+  if (configfile && pathExistsSync(configfile)) {
     grunt.verbose.writeln().write(msg).ok();
     // Change working directory so that all paths are relative to the
     // configfile's location (or the --base option, if specified).

--- a/lib/util/findup.js
+++ b/lib/util/findup.js
@@ -9,12 +9,14 @@
 
 // Nodejs libs.
 var path = require('path');
+var fs = require('fs');
+var pathExistsSync = fs.existsSync || path.existsSync;
 
 // Search for a filename in the given directory or all parent directories.
 module.exports = function findup(dirpath, filename) {
   var filepath = path.join(dirpath, filename);
   // Return file if found.
-  if (path.existsSync(filepath)) { return filepath; }
+  if (pathExistsSync(filepath)) { return filepath; }
   // If parentpath is the same as dirpath, we can't go any higher.
   var parentpath = path.resolve(dirpath, '..');
   return parentpath === dirpath ? null : findup(parentpath, filename);

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
   // Nodejs libs.
   var fs = require('fs');
   var path = require('path');
+  var pathExistsSync = fs.existsSync || path.existsSync;
 
   // ==========================================================================
   // TASKS
@@ -116,7 +117,7 @@ module.exports = function(grunt) {
         watchedFiles[filepath] = fs.watch(filepath, function(event) {
           var mtime;
           // Has the file been deleted?
-          var deleted = !path.existsSync(filepath);
+          var deleted = !pathExistsSync(filepath);
           if (deleted) {
             // If file was deleted, stop watching file.
             unWatchFile(filepath);


### PR DESCRIPTION
Just removing the deprecation warning on Node.js v0.8.x.
