### PR TITLE
Strip colors from grunt.log methods on `--no-color`

### DIFF
--- a/lib/grunt/log.js
+++ b/lib/grunt/log.js
@@ -13,6 +13,7 @@ var grunt = require('../grunt');
 
 // Nodejs libs.
 var util = require('util');
+var colors = require('colors');
 
 // The module to be exported.
 var log = module.exports = {};
@@ -38,6 +39,7 @@ function markup(str) {
 
 // Write output.
 log.write = function(msg) {
+  msg = grunt.option('no-color') ? colors.stripColors(msg) : msg;
   // Actually write output.
   if (!log.muted && !suppressOutput) {
     hasLogged = true;


### PR DESCRIPTION
Fixes #383

So I figured out why grunt wouldn't strip colors. It actually does, but only on console.log. I was using grunt.log.

I fixed it so that grunt.log.write, which I believe all of them eventually uses now strips colors when the `--no-color` flag is set.

I couldn't figure out how to actually test this, since it actually relies on a cli flag. Any pointers?
