### PR TITLE
Update lib/grunt/task.js

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -304,7 +304,7 @@ task.loadNpmTasks = function(name) {
   var pkg = existsSync(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
 
   // Process collection plugins.
-  if (pkg.keywords.indexOf('gruntcollection') !== -1) {
+  if (pkg.keywords && pkg.keywords.indexOf('gruntcollection') !== -1) {
     Object.keys(pkg.dependencies).forEach(function(depName) {
       // Npm sometimes pulls dependencies out if they're shared, so find
       // upwards if not found locally.


### PR DESCRIPTION
I wanted to use grunt-handlebars and it fails because this package has no keywords. I'm not sure but I think this commit can help for this case.
