### PR TITLE
init:gruntplugin watches/lints tasks instead of lib folder

### DIFF
--- a/tasks/init/gruntplugin/root/Gruntfile.js
+++ b/tasks/init/gruntplugin/root/Gruntfile.js
@@ -17,8 +17,8 @@ module.exports = function(grunt) {
       bin: {
         src: ['bin/{%= name %}']
       },
-      lib: {
-        src: ['lib/**/*.js']
+      tasks: {
+        src: ['tasks/**/*.js']
       },
       test: {
         src: ['test/**/*.js']
@@ -33,9 +33,9 @@ module.exports = function(grunt) {
         files: '<%= jshint.bin.src %>',
         tasks: ['jshint:bin']
       },
-      lib: {
-        files: '<%= jshint.lib.src %>',
-        tasks: ['jshint:lib', 'nodeunit']
+      tasks: {
+        files: '<%= jshint.tasks.src %>',
+        tasks: ['jshint:tasks', 'nodeunit']
       },
       test: {
         files: '<%= jshint.test.src %>',


### PR DESCRIPTION
The gruntplugin init template should watch and lint the `tasks` folder instead of the `lib` folder.
