### PR TITLE
Refined filter to only include _test.js files in the test directory.

### DIFF
--- a/tasks/init/gruntfile/root/grunt.js
+++ b/tasks/init/gruntfile/root/grunt.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
       files: ['{%= test_dir %}/**/*.html']
     },{% } else { %}
     test: {
-      files: ['{%= test_dir %}/**/*.js']
+      files: ['{%= test_dir %}/**/*_test.js']
     },{% } %}{% if (min_concat) { %}
     concat: {
       dist: {


### PR DESCRIPTION
Every time I use grunt I always encounter issues with grunt picking up every .js file in my test folder and trying to run them as nodeunit files.

This patch simply reduces the filter to match only files named _test.js to avoid this confusing others in the future.
