### PR TITLE
Refined filter to only include _test.js files in the test directory for all init templates.

### DIFF
--- a/tasks/init/gruntfile/root/Gruntfile.js
+++ b/tasks/init/gruntfile/root/Gruntfile.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
         src: 'Gruntfile.js'
       },
       lib_test: {
-        src: ['{%= lib_dir %}/**/*.js', '{%= test_dir %}/**/*_test.js']
+        src: ['{%= lib_dir %}/**/*.js', '{%= test_dir %}/**/*.js']
       }
     },{% if (dom) { %}
     {%= test_task %}: {

--- a/tasks/init/gruntplugin/root/Gruntfile.js
+++ b/tasks/init/gruntplugin/root/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     nodeunit: {
-      files: ['test/**/*.js']
+      files: ['test/**/*_test.js']
     },
     jshint: {
       options: {
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
         src: ['lib/**/*.js']
       },
       test: {
-        src: ['test/**/*_test.js']
+        src: ['test/**/*.js']
       },
     },
     watch: {

--- a/tasks/init/node/root/Gruntfile.js
+++ b/tasks/init/node/root/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     nodeunit: {
-      files: ['test/**/*.js'],
+      files: ['test/**/*_test.js'],
     },
     jshint: {
       options: {
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
         src: ['lib/**/*.js']
       },
       test: {
-        src: ['test/**/*_test.js']
+        src: ['test/**/*.js']
       },
     },
     watch: {


### PR DESCRIPTION
Every time I use grunt I always encounter issues with grunt picking up every .js file in my test folder and trying to run them as nodeunit files.

This patch simply reduces the filter to match only files named _test.js to avoid this confusing others in the future.

As per your request on #421 I have done applied this to all the tamplates that use nodeunit and pushed this to devel branch.
