### PR TITLE
Add new JSHint complexity options to grunt.js

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -36,7 +36,12 @@ module.exports = function(grunt) {
         boss: true,
         eqnull: true,
         node: true,
-        es5: true
+        es5: true,
+        strict: false,
+        maxparams: 5,
+        maxdepth: 4,
+        maxstatements: 33,
+        maxcomplexity: 15
       },
       globals: {}
     }


### PR DESCRIPTION
Added  the new JSHint options `maxparams`, `maxdepth`, `maxstatements`, and `maxcomplexity`

I went ahead and set them to the maximum value that the grunt codebase is currently at

``` javascript
maxparams: 5, 
maxdepth: 4, 
maxstatements: 33, 
maxcomplexity: 15
```
