### PR TITLE
Fix error stack traces and inheritance

### DIFF
--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -41,16 +41,18 @@
 
   // Error constructors.
   function TaskError(message) {
-    this.name = 'TaskError';
+    Error.captureStackTrace(this, TaskError);
     this.message = message;
   }
-  TaskError.prototype = new Error();
+  TaskError.prototype = Object.create(Error.prototype);
+  TaskError.prototype.name = 'TaskError';
 
   function HelperError(message) {
-    this.name = 'HelperError';
+    Error.captureStackTrace(this, HelperError);
     this.message = message;
   }
-  HelperError.prototype = new Error();
+  HelperError.prototype = Object.create(Error.prototype);
+  HelperError.prototype.name = 'HelperError';
 
   // Expose the ability to create a new taskError.
   Task.prototype.taskError = function(message, e) {


### PR DESCRIPTION
This drastically improved my ability to debug a "Task not found" error. It went from a completely useless and unreadable stack trace (consisting of line 47, then 390, then a bunch of requires), to one precisely tracing where the `TaskError` was actually thrown.
