### PR TITLE
Support for loading tasks available in global npm_modules directory

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -329,7 +329,15 @@ task.loadNpmTasks = function(name) {
     task.searchDirs.unshift(tasksdir);
     loadTasks(tasksdir);
   } else {
-    grunt.log.error('Local Npm module "' + name + '" not found. Is it installed?');
+    // Looking up in global npm directory. 
+    var node_modules = __dirname.split('node_modules')[0] + 'node_modules';
+    tasksdir = path.join(node_modules, name, 'tasks');
+    if (existsSync(tasksdir)) {
+      task.searchDirs.unshift(tasksdir);
+      loadTasks(tasksdir);
+    } else {
+      grunt.log.error('Npm module "' + name + '" not found. Is it installed?');  
+    }
   }
 };
 


### PR DESCRIPTION
Will simply go ahead and search for tasks in gloabl npm_modules directory, quiet handy when you dont want to install tasks locally for every project
