### PR TITLE
Fix broken JSON introduced in fbcaf00b

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "lib/grunt",
   "bin": "bin/grunt",
   "scripts": {
-    "test": "./bin/grunt npm-test",
+    "test": "./bin/grunt npm-test"
   },
   "engines": {
     "node": ">= 0.8.0"


### PR DESCRIPTION
A trailing comma is causing JSON to be invalid and preventing NPM from installing from Git.
