### PR TITLE
Better verbose logging for template errors

### DIFF
--- a/lib/grunt/template.js
+++ b/lib/grunt/template.js
@@ -73,6 +73,7 @@ template.process = function(template, data, mode) {
       last = template;
     }
   } catch (e) {
+    grunt.verbose.writeln(e.stack);
     grunt.warn('An error occurred while processing a template (' + e.message + ').');
   }
   // Normalize linefeeds and return.


### PR DESCRIPTION
I was getting a template error that just said `<WARN> An error occurred while processing a template (Cannot call method 'indexOf' of undefined). Use --force to continue. </WARN>` Which wasn't very helpful, (which template?). So I added a stack trace to the warning when running with `--verbose` so that I could find some info about the source of the issue.
