### PR TITLE
Only mess with uncaught exceptions during a grunt run.

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -54,11 +54,6 @@ gExpose(config, 'init', 'initConfig');
 gExpose(fail, 'warn');
 gExpose(fail, 'fatal');
 
-// Handle otherwise unhandleable (probably asynchronous) exceptions.
-process.on('uncaughtException', function (e) {
-  fail.fatal(e, fail.code.TASK_FAILURE);
-});
-
 // Expose the task interface. I've never called this manually, and have no idea
 // how it will work. But it might.
 grunt.tasks = function(tasks, options, done) {
@@ -106,12 +101,20 @@ grunt.tasks = function(tasks, options, done) {
   }
   verbose.writeflags(tasks, 'Running tasks');
 
+  // Handle otherwise unhandleable (probably asynchronous) exceptions.
+  var uncaughtHandler = function(e) {
+    fail.fatal(e, fail.code.TASK_FAILURE);
+  };
+  process.on('uncaughtException', uncaughtHandler);
+
   // Report, etc when all tasks have completed.
   task.options({
     error: function(e) {
       fail.warn(e, fail.code.TASK_FAILURE);
     },
     done: function() {
+      process.removeListener('uncaughtException', uncaughtHandler);
+
       // Output a final fail / success report.
       fail.report();
 


### PR DESCRIPTION
I had the need to do a `require('grunt')` in my own app. However just doing so would cause all uncaught exceptions in my own app to be caught by grunt, which would then print out the error message but leave out everything useful like the stack trace. In my case I actually had to require grunt during a test run (the app is a bit special, bear with me) so it was dying on every async assertion. In short, this behavior makes building an app around grunt very difficult.

Furthermore and in general, I believe you also agree that just requiring something should not alter your environment.

So, I made some minor changes: the uncaughtException handler is moved to right before the task run starts, and removed after finishing in the done callback. The error callback calls `fail.warn` which either exists directly or just keeps going, so I didn't add it there.

Seeing how the code is commented out in 0.3.17, I don't think this patch introduces any breaking changes.
