### PR TITLE
fix spawn so that it no longer throws an exception when stdio is configu...

### DIFF
--- a/lib/grunt/utils.js
+++ b/lib/grunt/utils.js
@@ -90,8 +90,12 @@ utils.spawn = function(opts, done) {
   var child = spawn(opts.cmd, opts.args, opts.opts);
   var stdout = '';
   var stderr = '';
-  child.stdout.on('data', function(buf) { stdout += buf; });
-  child.stderr.on('data', function(buf) { stderr += buf; });
+  if ( child.stdout ){
+    child.stdout.on('data', function(buf) { stdout += buf; });
+  }
+  if ( child.stderr ) {
+    child.stderr.on('data', function(buf) { stderr += buf; });
+  }
   // Node 0.8 no longer waits for stdio pipes to be closed before emitting the
   // exit event (grunt issue #322).
   var eventName = process.version.split('.')[1] === '6' ? 'exit' : 'close';

--- a/test/grunt/utils_test.js
+++ b/test/grunt/utils_test.js
@@ -18,5 +18,38 @@ exports['utils'] = {
       test.equal(grunt.utils.normalizelf('foo\nbar\r\nbaz\r\n\r\nqux\n\nquux'), 'foo\nbar\nbaz\n\nqux\n\nquux', 'linefeeds should be normalized');
     }
     test.done();
+  },
+  'spawn': function(test) {
+    test.expect();
+
+    grunt.utils.spawn({
+          cmd: 'echo',
+          args: ['"hello world"'],
+          opts: {
+               stdio: 'inherit'
+          },
+          fallback: 'none'
+      },
+      function(error, result, code) {
+         test.equals(result.stdout, '', 'Nothing will be passed to the stdout string when spawn stdio is configured for inherit');
+        test.done();
+      }
+    );
+    
+  },
+  'spawn-stdio-inherit': function(test) {
+    test.expect(1);
+
+    grunt.utils.spawn({
+          cmd: 'echo',
+          args: ['hello world2'],
+          fallback: 'none'
+      },
+      function(error, result, code) {
+        test.equals(result.stdout, 'hello world2', 'Should return stdout result.');
+        test.done();
+      }
+    );
+    
   }
 };


### PR DESCRIPTION
...red to inherit.

When then spawn is configured with the option stdio: 'inherit' grunt throws an exception.  This should fix that.  Tests are included.
