### PR TITLE
dump a stack trace to verbose on template errors

### DIFF
--- a/lib/grunt/template.js
+++ b/lib/grunt/template.js
@@ -92,6 +92,7 @@ template.process = function(tmpl, options) {
         'Inside template tags, the \\n and \\r special characters must be ' +
         'escaped as \\\\n and \\\\r. (grunt 0.4.0+)');
     }
+    grunt.verbose.writeln(e.stack);
     grunt.warn('An error occurred while processing a template (' + e.message + ').',
       grunt.fail.code.TEMPLATE_ERROR);
   }


### PR DESCRIPTION
In the event of a template error it helps to have a stack trace to find the template that causes the error. This puts the stack trace into the verbose log.
