### PR TITLE
Use phantomjs npm module for qunit task

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,20 +22,6 @@ This is the `DOSKEY` command you'd use:
 DOSKEY grunt=grunt.cmd $*
 ```
 
-## Why does grunt complain that PhantomJS isn't installed?
-In order for the [qunit task](task_qunit.md) to work properly, [PhantomJS](http://www.phantomjs.org/) must be installed and in the system PATH (if you can run "phantomjs" at the command line, this task should work).
-
-Unfortunately, PhantomJS cannot be installed automatically via npm or grunt, so you need to install it yourself. There are a number of ways to install PhantomJS.
-
-* [PhantomJS and Mac OS X](http://ariya.ofilabs.com/2012/02/phantomjs-and-mac-os-x.html)
-* [PhantomJS Installation](http://code.google.com/p/phantomjs/wiki/Installation) (PhantomJS wiki)
-
-Note that the `phantomjs` executable needs to be in the system `PATH` for grunt to see it.
-
-* [How to set the path and environment variables in Windows](http://www.computerhope.com/issues/ch000549.htm)
-* [Where does $PATH get set in OS X 10.6 Snow Leopard?](http://superuser.com/questions/69130/where-does-path-get-set-in-os-x-10-6-snow-leopard)
-* [How do I change the PATH variable in Linux](https://www.google.com/search?q=How+do+I+change+the+PATH+variable+in+Linux)
-
 ## Why doesn't my asynchronous task complete?
 Chances are this is happening because you have forgotten to call the [this.async](api_task.md#thisasync--grunttaskcurrentasync) method to tell grunt that your task is asynchronous. For simplicity's sake, grunt uses a synchronous coding style, which can be switched to asynchronous by calling `this.async()` within the task body.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/gruntjs/grunt.git"
   },
   "bugs": {
-    "url" : "http://github.com/gruntjs/grunt/issues"
+    "url": "http://github.com/gruntjs/grunt/issues"
   },
   "licenses": [
     {
@@ -60,7 +60,8 @@
     "underscore": "~1.2.4",
     "underscore.string": "~2.1.1",
     "temporary": "~0.0.4",
-    "gzip-js": "~0.3.1"
+    "gzip-js": "~0.3.1",
+    "phantomjs": "~0.2.3"
   },
   "devDependencies": {}
 }

--- a/tasks/qunit.js
+++ b/tasks/qunit.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
   // Nodejs libs.
   var fs = require('fs');
   var path = require('path');
+  var phantomjs = require('phantomjs');
 
   // External libs.
   var Tempfile = require('temporary/lib/file');
@@ -230,27 +231,15 @@ module.exports = function(grunt) {
 
   grunt.registerHelper('phantomjs', function(options) {
     return grunt.utils.spawn({
-      cmd: 'phantomjs',
+      cmd: phantomjs.path,
       args: options.args
     }, function(err, result, code) {
       if (!err) { return options.done(null); }
       // Something went horribly wrong.
       grunt.verbose.or.writeln();
       grunt.log.write('Running PhantomJS...').error();
-      if (code === 127) {
-        grunt.log.errorlns(
-          'In order for this task to work properly, PhantomJS must be ' +
-          'installed and in the system PATH (if you can run "phantomjs" at' +
-          ' the command line, this task should work). Unfortunately, ' +
-          'PhantomJS cannot be installed automatically via npm or grunt. ' +
-          'See the grunt FAQ for PhantomJS installation instructions: ' +
-          'https://github.com/gruntjs/grunt/blob/master/docs/faq.md'
-        );
-        grunt.warn('PhantomJS not found.', options.code);
-      } else {
-        result.split('\n').forEach(grunt.log.error, grunt.log);
-        grunt.warn('PhantomJS exited unexpectedly with exit code ' + code + '.', options.code);
-      }
+      result.split('\n').forEach(grunt.log.error, grunt.log);
+      grunt.warn('PhantomJS exited unexpectedly with exit code ' + code + '.', options.code);
       options.done(code);
     });
   });


### PR DESCRIPTION
PhantomJS can be installed via NPM now, so use this module instead of
requiring users to install it in the PATH.
