### PR TITLE
fix spawn so that it no longer throws an exception when stdio is configu...

### DIFF
--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -157,8 +157,12 @@ util.spawn = function(opts, done) {
   var child = spawn(cmd, args, opts.opts);
   var stdout = '';
   var stderr = '';
-  child.stdout.on('data', function(buf) { stdout += buf; });
-  child.stderr.on('data', function(buf) { stderr += buf; });
+  if ( child.stdout ){
+    child.stdout.on('data', function(buf) { stdout += buf; });
+  }
+  if ( child.stderr ) {
+    child.stderr.on('data', function(buf) { stderr += buf; });
+  }
   child.on('close', function(code) {
     callDone(code, stdout, stderr);
   });

--- a/test/grunt/util_test.js
+++ b/test/grunt/util_test.js
@@ -199,6 +199,22 @@ exports['util.spawn'] = {
       test.done();
     });
   },
+  'spawn stio inherit': function(test) {
+    test.expect(1);
+
+    grunt.util.spawn({
+        cmd: 'echo',
+        args: ['"hello world"'],
+        opts: {
+             stdio: 'inherit'
+        },
+        fallback: 'none'
+      },
+      function(error, result) {
+        test.equals(result.stdout, '', 'Nothing will be passed to the stdout string when spawn stdio is configured for inherit');
+        test.done();
+      });
+  }
 };
 
 exports['util.underscore.string'] = function(test) {


### PR DESCRIPTION
...red to inherit.

When then spawn is configured with the option stdio: 'inherit' grunt throws an exception. This should fix that. Test is included.
