### PR TITLE
add noProcessExt option to file.copy

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -29,6 +29,11 @@ var iconv = require('iconv-lite');
 // Windows?
 var win32 = process.platform === 'win32';
 
+var binaryExtensions = [
+  'dds', 'eot', 'gif', 'ico', 'jar', 'jpeg', 'jpg',
+  'otf', 'pdf', 'png', 'swf', 'tga', 'ttf', 'woff', 'zip'
+];
+
 // Normalize \\ paths to / paths.
 var unixifyPath = function(filepath) {
   if (win32) {
@@ -309,10 +314,16 @@ file.write = function(filepath, contents, options) {
 // Read a file, optionally processing its content, then write the output.
 file.copy = function(srcpath, destpath, options) {
   if (!options) { options = {}; }
+  options.noProcessExt = grunt.util._.union(binaryExtensions, options.noProcessExt || []);
+
+  var srcExt = srcpath.replace(/.*[\.\/]/, '').toLowerCase();
+
   // If a process function was specified, and noProcess isn't true or doesn't
   // match the srcpath, process the file's source.
   var process = options.process && options.noProcess !== true &&
-    !(options.noProcess && file.isMatch(options.noProcess, srcpath));
+    !(options.noProcess && file.isMatch(options.noProcess, srcpath)) &&
+    !(options.noProcessExt && grunt.util._.contains(options.noProcessExt, srcExt));
+
   // If the file will be processed, use the encoding as-specified. Otherwise,
   // use an encoding of null to force the file to be read/written as a Buffer.
   var readWriteOptions = process ? options : {encoding: null};

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -481,7 +481,7 @@ exports['file'] = {
     test.done();
   },
   'copy and process, noprocess': function(test) {
-    test.expect(4);
+    test.expect(6);
     var tmpfile;
     tmpfile = new Tempfile();
     grunt.file.copy('test/fixtures/utf8.txt', tmpfile.path, {
@@ -510,6 +510,25 @@ exports['file'] = {
       }
       tmpfile.unlinkSync();
     }, this);
+
+    tmpfile = new Tempfile();
+    grunt.file.copy('test/fixtures/octocat.png', tmpfile.path, {
+      process: function() {
+        return 'content';
+      }
+    });
+    test.notEqual(grunt.file.read(tmpfile.path), 'content', 'file should not have been processed.');
+    tmpfile.unlinkSync();
+
+    tmpfile = new Tempfile();
+    grunt.file.copy('test/fixtures/utf8.txt', tmpfile.path, {
+      process: function(src) {
+        return 'føø' + src + 'bår';
+      },
+      noProcessExt: ['txt']
+    });
+    test.equal(grunt.file.read(tmpfile.path), this.string, 'file should not have been processed.');
+    tmpfile.unlinkSync();
 
     test.done();
   },


### PR DESCRIPTION
this prevents processing by file extension. includes a sane list of binary file extensions to prevent corruption.

this carries benefits for any task that uses `file.copy` vs having to implement in each task. tasks can always define an extended list of defaults that users can also extend. this is a lot more flexible than `noProcess` in a lot of cases.
