### PR TITLE
Turn grunt.log into a readable stream

### DIFF
--- a/lib/grunt/log.js
+++ b/lib/grunt/log.js
@@ -13,9 +13,16 @@ var grunt = require('../grunt');
 
 // Nodejs libs.
 var util = require('util');
+var Stream = require('stream');
 
 // The module to be exported.
-var log = module.exports = {};
+var log = module.exports = new Stream();
+
+// Make stream readable
+log.readable = true;
+
+// By default pipe to stdout
+log.pipe(process.stdout);
 
 // External lib. Requiring this here modifies the String prototype!
 var colors = require('colors');
@@ -63,8 +70,8 @@ log.write = function(msg) {
     // Users should probably use the colors-provided methods, but if they
     // don't, this should strip extraneous color codes.
     if (grunt.option('no-color')) { msg = colors.stripColors(msg); }
-    // Actually write to stdout.
-    process.stdout.write(markup(msg));
+    // emit msg to the stream
+    log.emit('data', markup(msg));
   }
   // Chainable!
   return this;

--- a/test/grunt/log_test.js
+++ b/test/grunt/log_test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var grunt = require('../../lib/grunt');
+var fs = require('fs');
+var Tempfile = require('temporary/lib/file');
 
 // Helper for testing stdout
 var hooker = grunt.util.hooker;
@@ -115,5 +117,22 @@ exports['log'] = {
     }, 'test: foo, bar\n');
 
     test.done();
-  }
+  },
+  'stream': function(test) {
+    test.expect(2);
+    stdoutEqual(test, function() {
+      var tmpfile = new Tempfile();
+      var writeStream = fs.createWriteStream(tmpfile.path);
+
+      grunt.log.pipe(writeStream);
+      grunt.log.write('foo');
+      grunt.log.writeln('bar');
+
+      writeStream.on('close', function() {
+        test.equal(grunt.file.read(tmpfile.path), 'foobar\n');
+        test.done();
+      });
+      writeStream.end();
+    }, 'foobar\n');
+  },
 };


### PR DESCRIPTION
This is an alternate to PR #570 and makes `grunt.log` a readable stream (instead of passing an argument).

`grunt.log` will function as normal but now a user can tap into the stream:

``` javascript
grunt.log.on('data', function(msg) {
  // handle some fancy reporting here
});
```

Or pipe the output to a logfile:

``` javascript
grunt.log.pipe(fs.createWriteStream('./logfile.txt'));
```

Which will write everything to `./logfile.txt` in addition to writing to `process.stdout`.

EDIT: I understand this might be a v0.5 thing ;)
