### PR TITLE
Allow tasks to ignore AssertionError for tests

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -56,6 +56,13 @@ gExpose(fail, 'fatal');
 
 // Handle otherwise unhandleable (probably asynchronous) exceptions.
 process.on('uncaughtException', function (e) {
+  // Some testing frameworks (eg: mocha), rely on uncaught Assertions.
+  if (grunt.task.current.options().ignoreAssertions &&
+      e.name === 'AssertionError') {
+    return;
+  }
+
+  // Otherwise, fail completely
   fail.fatal(e, fail.code.TASK_FAILURE);
 });
 

--- a/test/fixtures/Gruntfile-assertion-error.js
+++ b/test/fixtures/Gruntfile-assertion-error.js
@@ -1,0 +1,21 @@
+var assert = require('assert');
+module.exports = function(grunt) {
+    grunt.initConfig({
+        assertFail: {
+            bad: {},
+            ok: {
+                options: {
+                    ignoreAssertions: true
+                }
+            },
+        },
+    });
+
+    grunt.registerMultiTask('assertFail', 'Causes an assertion failure', function() {
+        var done = this.async();
+        setTimeout(function() {
+            assert(false, 'tddplz');
+            done();
+        }, 0);
+    });
+};

--- a/test/grunt/util_test.js
+++ b/test/grunt/util_test.js
@@ -255,6 +255,30 @@ exports['util.spawn'] = {
     test.ok(!child.stdout, 'child should not have a stdout property.');
     test.ok(!child.stderr, 'child should not have a stderr property.');
   },
+  'returns errors to calling process': function(test) {
+    test.expect(2);
+    grunt.util.spawn({
+      grunt: true,
+      args: [ '--gruntfile', 'test/fixtures/Gruntfile-assertion-error.js', 'assertFail:bad' ],
+    }, function(err, result, code) {
+      test.equals(code, 3, 'should return an error code on assertion failure');
+      var outHasFail = /Fatal error: tddplz/.test(result.stdout);
+      test.ok(outHasFail, 'stdout should contain output indicating failure.');
+      test.done();
+    });
+  },
+  'ignoreAssertions allows us to continue': function(test) {
+    test.expect(2);
+    grunt.util.spawn({
+      grunt: true,
+      args: [ '--gruntfile', 'test/fixtures/Gruntfile-assertion-error.js', 'assertFail:ok' ],
+    }, function(err, result, code) {
+      test.equals(code, 0, 'with ignoreAssertions, should get no error code.');
+      var outHasFail = /Fatal error: tddplz/.test(result.stdout);
+      test.ok(!outHasFail, 'stderr should not contain failure output.');
+      test.done();
+    });
+  },
 };
 
 exports['util.underscore.string'] = function(test) {


### PR DESCRIPTION
Mocha relies on `uncaughtException` to determine test failures (https://github.com/visionmedia/mocha/blob/master/lib/runner.js#L449-473). Since grunt bails completely on uncaught exceptions, mocha test runners can never continue reporting after a failure. This fixes that by allowing a task option `ignoreAssertions` which, when set, simply continues on uncaught exceptions for that task.

Associated tests included.

As docs have now moved to the wiki, how should one best associate doc changes with pull requests?
