### PR TITLE
Add beep option (default true)

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -28,7 +28,11 @@ fail.code = {
 function writeln(e, mode) {
   grunt.log.muted = false;
   var msg = String(e.message || e);
-  if (!grunt.option('no-color') && !grunt.option('no-beep')) { msg += '\x07'; } // Beep!
+  var beep = true;
+  if (grunt.option('no-color') || grunt.option('no-beep')) {
+    beep = false;
+  }
+  if (beep) { msg += '\x07'; } // Beep!
   if (mode === 'warn') {
     msg = 'Warning: ' + msg + ' ';
     msg += (grunt.option('force') ? 'Used --force, continuing.'.underline : 'Use --force to continue.');


### PR DESCRIPTION
This pull request is much the same #190 but default beep is on.
That request is closed but I want  this option because I use beep in other program and can't disable beep from system
