### PR TITLE
Proof of concept for only 'compiling what is needed' (gh-593)

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -446,3 +446,8 @@ file.isPathInCwd = function() {
     return false;
   }
 };
+
+// Retrieve the computed state of the file using witness.
+file.state = function() {
+  return grunt.util.witness.state.apply(grunt.util.witness, arguments);
+};

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -224,7 +224,9 @@ task.registerMultiTask = function(name, info, fn) {
 
       // Actually run the task function (handling this.async, etc)
       task.runTaskFn(context, function() {
-        return fn.apply(this, this.args);
+        var result = fn.apply(this, this.args);
+        grunt.util.witness.store();
+        return result;
       }, next);
 
     }.bind(this), this.async());

--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -25,6 +25,9 @@ util.namespace = require('../util/namespace');
 util.exit = require('../util/exit').exit;
 
 // External libs.
+var Witness = require('witness');
+util.witness = new Witness('./.witness-cache.json');
+
 util.hooker = require('hooker');
 util.async = require('async');
 var _ = util._ = require('lodash');

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "lodash": "~0.9.0",
     "underscore.string": "~2.2.0rc",
     "which": "~1.0.5",
-    "js-yaml": "~1.0.1"
+    "js-yaml": "~1.0.1",
+    "witness": "0.0.x"
   },
   "devDependencies": {
     "temporary": "~0.0.4",


### PR DESCRIPTION
This is a proof-of-concept implementation of what I discussed on #593.

This adds the https://github.com/concordusapps/witness library to the `grunt.util` namespace (as well as a helper in the `grunt.file` namespace).

Now, from inside a task; one may filter oneself using something like the following:

``` javascript
var exists = grunt.file.exists(dest);
var changed = grunt.util._.any(files, function(file) {
  return grunt.file.state(file, 'grunt-contrib-coffee') !== 'ready';
});

if (!exists || changed) {
  // Perform task ...
}
```

https://github.com/concordusapps/grunt-contrib-coffee is a working implementation of the above.

The `grunt.file.state` (delegates to `grunt.util.witness.state`) takes two parameters. The file path and an optional context. The context is there so that each context can be informed about a state change once. 

``` javascript
// Now if we assume we modified the content again. Notice how 'apple' and
// 'orange' only get notified about the changed event once.

witness.state('src/one.coffee', 'apple');   // == 'changed'
witness.state('src/one.coffee', 'orange');  // == 'changed'
witness.state('src/one.coffee', 'apple');   // == 'ready'
witness.state('src/one.coffee', 'orange');  // == 'ready'
```

Thoughts, concerns, etc.?

---

The next step after this for the library is to integrate into grunt-contrib-watch so its only notified when necessary.
