### PR TITLE
Waiting for output streams to have finished before exiting grunt.

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -132,7 +132,8 @@ grunt.tasks = function(tasks, options, done) {
         done();
       } else {
         // Otherwise, explicitly exit.
-        process.exit(0);
+        var exitProcess = require('./util/exit');
+        exitProcess(0);
       }
     }
   });

--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -11,6 +11,7 @@ var grunt = require('../grunt');
 
 // The module to be exported.
 var fail = module.exports = {};
+var exitProcess = require('../util/exit');
 
 // Error codes
 // 1. Generic error.
@@ -36,10 +37,10 @@ function writeln(e, mode) {
   grunt.log.writeln([tags[mode][0], msg.yellow, tags[mode][1]].join(' '));
 }
 
-// A fatal error occured. Abort immediately.
+// A fatal error occured. Abort immediately (as soon as stdout and stderr have received all their data).
 fail.fatal = function(e, errcode) {
   writeln(e, 'fatal');
-  process.exit(typeof errcode === 'number' ? errcode : 1);
+  exitProcess(typeof errcode === 'number' ? errcode : 1);
 };
 
 // Keep track of error and warning counts.
@@ -70,7 +71,7 @@ fail.warn = function(e, errcode) {
       }
       // Log and exit.
       grunt.log.writeln().fail('Aborted due to warnings.');
-      process.exit(typeof errcode === 'number' ? errcode : 2);
+      exitProcess(typeof errcode === 'number' ? errcode : 2);
     }
   }
 };

--- a/lib/grunt/help.js
+++ b/lib/grunt/help.js
@@ -65,5 +65,5 @@ grunt.log.writeln().writelns(
   '\n\n' +
   'For more information, see http://gruntjs.com/'
 );
-
-process.exit();
+var exitProcess = require('../util/exit');
+exitProcess();

--- a/lib/util/exit.js
+++ b/lib/util/exit.js
@@ -1,0 +1,25 @@
+// Waits for the stream to have fully received its content.
+var waitForStreamEnd = function (stream, callback) {
+    // Writes an empty string to check the state of the buffer:
+    if (!stream.write("")) {
+        stream.once('drain', callback);
+    } else {
+        callback();
+    }
+};
+
+// Exits the process asynchronously, making sure the stdout and stderr streams have fully received their content.
+var exitProcess = function (exitCode) {
+    var ok = 0;
+    var increaseOk = function () {
+        ok++;
+        if (ok == 3) {
+            process.exit(exitCode);
+        }
+    };
+    waitForStreamEnd(process.stdout, increaseOk);
+    waitForStreamEnd(process.stderr, increaseOk);
+    process.nextTick(increaseOk);
+};
+
+module.exports = exitProcess;


### PR DESCRIPTION
When calling `grunt` and piping its output to some other application (this happens for example when calling it from Cygwin bash under Windows, or as part of a larger build process), the end of the output from Grunt is often lost, because Grunt is exiting before all the data has been sent.

This pull request adds some code to make sure all the output has been received by `stdin` and `stdout` before exiting.

You can check this for more information:
https://groups.google.com/forum/?fromgroups=#!topic/nodejs-dev/Tj_HNQbvtZs
