### PR TITLE
Update js-yaml dependency: 1.0.x -> 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lodash": "~0.9.0",
     "underscore.string": "~2.2.0rc",
     "which": "~1.0.5",
-    "js-yaml": "~1.0.1"
+    "js-yaml": "~2.0.2"
   },
   "devDependencies": {
     "temporary": "~0.0.4",


### PR DESCRIPTION
js-yaml v2 is much faster and have compatible API. At least, tests passed :)
