### PR TITLE
log.wordlist now accepts an array of colors in options

### DIFF
--- a/lib/grunt/log.js
+++ b/lib/grunt/log.js
@@ -190,7 +190,7 @@ log.wordlist = function(arr, options) {
     separator: ', ',
     color: 'cyan'
   });
-  return arr.map(function(item) {
+  return arr.map(function(item, i) {
     return ( options.color ) ? ( grunt.util.kindOf(options.color) === 'array' ) ? String(item)[options.color[i]] : String(item)[options.color] : item;
   }).join(options.separator);
 };


### PR DESCRIPTION
Updated the wordlist method to accept an array of colors to color each item individually.

Example:

```
grunt.log.wordlist(['first', 'second ', 'third'], {
  color: ['green', 'blue', 'red']
});
```

There weren't any tests written for wordlist so I haven't included any with this update. I have tested locally not passing a value, passing a single value, passing an array of values, passing a falsy value. Each of these behaved as expected.

The only cavat currently is the number of colors must match the number of words or the word will be omitted. 

Example:

```
grunt.log.wordlist(['first', 'second ', 'third'], {
  color: ['green', 'blue']
});
```

Would return: `first, second,`

I didn't put checks in for this because I was trying to keep the change small.
