### PR TITLE
avoid losing error messages due to grunt.error.log using stdout instead of stderr

### DIFF
--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -132,7 +132,15 @@ util.spawn = function(opts, done) {
       stderr: stderr,
       code: code,
       toString: function() {
-        return code === 0 ? stdout : 'fallback' in opts ? opts.fallback : stderr;
+        if (code === 0) {
+          return stdout;
+        } else if ('fallback' in opts) {
+          return opts.fallback;
+        } else if (opts.grunt) {
+          // grunt.log.error uses standard out, to be fixed in 0.5.
+          return stderr || stdout;
+        }
+        return stderr;
       }
     };
     // On error (and no fallback) pass an error object, otherwise pass null.

--- a/test/grunt/util_test.js
+++ b/test/grunt/util_test.js
@@ -233,6 +233,20 @@ exports['util.spawn'] = {
       test.done();
     });
   },
+  'grunt result.toString() with error': function(test) {
+    // grunt.log.error uses standard out, to be fixed in 0.5.
+    test.expect(4);
+    grunt.util.spawn({
+      grunt: true,
+      args: [ 'nonexistantTask' ]
+    }, function(err, result, code) {
+      test.ok(err instanceof Error, 'Should be an Error.');
+      test.equal(err.name, 'Error', 'Should be an Error.');
+      test.equals(code, 3);
+      test.ok(/Warning: Task "nonexistantTask" not found./m.test(result.toString()), 'stdout should contain output indicating the grunt task was run.');
+      test.done();
+    });
+  },
   'custom stdio stream(s)': function(test) {
     test.expect(6);
     var stdoutFile = new Tempfile();


### PR DESCRIPTION
Since `grunt.log.error` currently use `stdout` instead of `stderr`, when an error happens when using `grunt.spawn` to spawn other Grunt tasks, the error can be lost when using `results.toString()`. 

I've modified `spawn`'s `results.toString()` to fall back to  `stdout` when  `grunt` is being spawned and `stderr` is empty.

Note 1: I saw a comment from @Cowboy that said we'll move to `stderr` in Grunt 0.5. I think that's good, but in the meanwhile this will help with problems we've had that we difficult to solve because of the lost error messages. I don't think the changes in this ticket will need to be rolled back when we move to `stderr`.

Note 2: One example of this problem happens in [grunt-parallel](https://github.com/iammerrick/grunt-parallel). You wouldn't see failed task output unless you set `options: { stdio: "inherit"}` which has other consequences that may not be desired. I submitted iammerrick/grunt-parallel/pull/2 to work around this issue but it felt like a hack to work around fault in Grunt, hence this PR. 
