### PR TITLE
Remove extra commas

### DIFF
--- a/test/grunt/config_test.js
+++ b/test/grunt/config_test.js
@@ -13,11 +13,11 @@ exports['config'] = {
         foo: '<%= meta.foo %>',
         foo2: '<%= obj.foo %>',
         Arr: ['foo', '<%= obj.foo2 %>'],
-        arr2: ['<%= arr %>', '<%= obj.Arr %>'],
+        arr2: ['<%= arr %>', '<%= obj.Arr %>']
       },
       bar: 'bar',
       arr: ['foo', '<%= obj.foo2 %>'],
-      arr2: ['<%= arr %>', '<%= obj.Arr %>'],
+      arr2: ['<%= arr %>', '<%= obj.Arr %>']
     });
     done();
   },
@@ -106,5 +106,5 @@ exports['config'] = {
     test.throws(function() { grunt.config.requires('foo', ['obj', 'foo'], ['obj', 'xyz']); }, 'One property does not exist.');
     grunt.log.muted = false;
     test.done();
-  },
+  }
 };

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -157,7 +157,7 @@ exports['file.expand*'] = {
     ], 'should match directories only.');
     test.deepEqual(grunt.file.expand({filter: function(filepath) { return (/deepest/).test(filepath); }}, '**'), [
       'deep/deeper/deepest',
-      'deep/deeper/deepest/deepest.txt',
+      'deep/deeper/deepest/deepest.txt'
     ], 'should filter arbitrarily.');
     test.deepEqual(grunt.file.expand({filter: 'isFile'}, 'js', 'css'), [], 'should fail to match.');
     test.deepEqual(grunt.file.expand({filter: 'isDirectory'}, '**/*.js'), [], 'should fail to match.');
@@ -231,7 +231,7 @@ exports['file.expand*'] = {
     test.deepEqual(grunt.file.expand(opts, ['js/a*', 'js/b*', 'js/c*']), ['js/a*', 'js/bar.js', 'js/c*'], 'non-matching patterns should be returned in result set.');
     test.deepEqual(grunt.file.expand(opts, ['js/foo.js', 'js/bar.js', 'js/baz.js']), ['js/foo.js', 'js/bar.js', 'js/baz.js'], 'non-matching filenames should be returned in result set.');
     test.done();
-  },
+  }
 };
 
 exports['file.expandMapping'] = {
@@ -251,7 +251,7 @@ exports['file.expandMapping'] = {
     var expected = [
       {dest: 'dest/expand/deep/deep.txt', src: ['expand/deep/deep.txt']},
       {dest: 'dest/expand/deep/deeper/deeper.txt', src: ['expand/deep/deeper/deeper.txt']},
-      {dest: 'dest/expand/deep/deeper/deepest/deepest.txt', src: ['expand/deep/deeper/deepest/deepest.txt']},
+      {dest: 'dest/expand/deep/deeper/deepest/deepest.txt', src: ['expand/deep/deeper/deepest/deepest.txt']}
     ];
     test.deepEqual(actual, expected, 'basic src-dest options');
 
@@ -266,7 +266,7 @@ exports['file.expandMapping'] = {
     var expected = [
       {dest: 'dest/deep.txt', src: ['expand/deep/deep.txt']},
       {dest: 'dest/deeper.txt', src: ['expand/deep/deeper/deeper.txt']},
-      {dest: 'dest/deepest.txt', src: ['expand/deep/deeper/deepest/deepest.txt']},
+      {dest: 'dest/deepest.txt', src: ['expand/deep/deeper/deepest/deepest.txt']}
     ];
     test.deepEqual(actual, expected, 'dest paths should be flattened pre-destBase+destPath join');
     test.done();
@@ -278,14 +278,14 @@ exports['file.expandMapping'] = {
     expected = [
       {dest: 'dest/expand/deep/deep.foo', src: ['expand/deep/deep.txt']},
       {dest: 'dest/expand/deep/deeper/deeper.foo', src: ['expand/deep/deeper/deeper.txt']},
-      {dest: 'dest/expand/deep/deeper/deepest/deepest.foo', src: ['expand/deep/deeper/deepest/deepest.txt']},
+      {dest: 'dest/expand/deep/deeper/deepest/deepest.foo', src: ['expand/deep/deeper/deepest/deepest.txt']}
     ];
     test.deepEqual(actual, expected, 'specified extension should be added');
     actual = grunt.file.expandMapping(['expand-mapping-ext/**/file*'], 'dest', {ext: '.foo'});
     expected = [
       {dest: 'dest/expand-mapping-ext/dir.ectory/file-no-extension.foo', src: ['expand-mapping-ext/dir.ectory/file-no-extension']},
       {dest: 'dest/expand-mapping-ext/dir.ectory/sub.dir.ectory/file.foo', src: ['expand-mapping-ext/dir.ectory/sub.dir.ectory/file.ext.ension']},
-      {dest: 'dest/expand-mapping-ext/file.foo', src: ['expand-mapping-ext/file.ext.ension']},
+      {dest: 'dest/expand-mapping-ext/file.foo', src: ['expand-mapping-ext/file.ext.ension']}
     ];
     test.deepEqual(actual, expected, 'specified extension should be added');
     test.done();
@@ -296,7 +296,7 @@ exports['file.expandMapping'] = {
     var expected = [
       {dest: 'dest/deep/deep.txt', src: ['expand/deep/deep.txt']},
       {dest: 'dest/deep/deeper/deeper.txt', src: ['expand/deep/deeper/deeper.txt']},
-      {dest: 'dest/deep/deeper/deepest/deepest.txt', src: ['expand/deep/deeper/deepest/deepest.txt']},
+      {dest: 'dest/deep/deeper/deepest/deepest.txt', src: ['expand/deep/deeper/deepest/deepest.txt']}
     ];
     test.deepEqual(actual, expected, 'cwd should be stripped from front of destPath, pre-destBase+destPath join');
     test.done();
@@ -313,7 +313,7 @@ exports['file.expandMapping'] = {
     var expected = [
       {dest: 'dest/expand/o-m-g/deep.txt', src: ['expand/deep/deep.txt']},
       {dest: 'dest/expand/o-m-g/deeper.txt', src: ['expand/deep/deeper/deeper.txt']},
-      {dest: 'dest/expand/o-m-g/deepest.txt', src: ['expand/deep/deeper/deepest/deepest.txt']},
+      {dest: 'dest/expand/o-m-g/deepest.txt', src: ['expand/deep/deeper/deepest/deepest.txt']}
     ];
     test.deepEqual(actual, expected, 'custom rename function should be used to build dest, post-flatten');
     test.done();
@@ -332,11 +332,11 @@ exports['file.expandMapping'] = {
       {dest: 'dest/all.md', src: ['expand/README.md']},
       {dest: 'dest/all.css', src: ['expand/css/baz.css', 'expand/css/qux.css']},
       {dest: 'dest/all.txt', src: ['expand/deep/deep.txt', 'expand/deep/deeper/deeper.txt', 'expand/deep/deeper/deepest/deepest.txt']},
-      {dest: 'dest/all.js', src: ['expand/js/bar.js', 'expand/js/foo.js']},
+      {dest: 'dest/all.js', src: ['expand/js/bar.js', 'expand/js/foo.js']}
     ];
     test.deepEqual(actual, expected, 'if dest is same for multiple src, create an array of src');
     test.done();
-  },
+  }
 };
 
 
@@ -755,5 +755,5 @@ exports['file'] = {
     test.equal(grunt.file.isPathInCwd('/'), false, 'root is not in cwd (I hope)');
     test.equal(grunt.file.isPathInCwd('nonexistent'), false, 'nonexistent path is not in cwd');
     test.done();
-  },
+  }
 };

--- a/test/grunt/option_test.js
+++ b/test/grunt/option_test.js
@@ -37,5 +37,5 @@ exports['option'] = {
     });
     test.deepEqual(grunt.option.flags(), ['--foo=bar', '--there', '--obj=[object Object]']);
     test.done();
-  },
+  }
 };

--- a/test/grunt/task_test.js
+++ b/test/grunt/task_test.js
@@ -24,8 +24,8 @@ exports['task.normalizeMultiTaskFiles'] = {
       {
         dest: 'dist/built.js',
         src: ['src/file1.js'],
-        orig: {dest: key, src: [value]},
-      },
+        orig: {dest: key, src: [value]}
+      }
     ];
     test.deepEqual(actual, expected, 'should normalize destTarget: srcString.');
 
@@ -36,8 +36,8 @@ exports['task.normalizeMultiTaskFiles'] = {
       {
         dest: 'dist/built.js',
         src: ['src/file1.js', 'src/file2.js'],
-        orig: {dest: key, src: flatten(value)},
-      },
+        orig: {dest: key, src: flatten(value)}
+      }
     ];
     test.deepEqual(actual, expected, 'should normalize destTarget: srcArray.');
 
@@ -50,8 +50,8 @@ exports['task.normalizeMultiTaskFiles'] = {
       {
         dest: 'dist/built.js',
         src: ['src/file1.js', 'src/file2.js'],
-        orig: value,
-      },
+        orig: value
+      }
     ];
     test.deepEqual(actual, expected, 'should normalize target: {src: srcStuff, dest: destStuff}.');
 
@@ -66,13 +66,13 @@ exports['task.normalizeMultiTaskFiles'] = {
       {
         dest: 'dist/built-a.js',
         src: ['src/file1.js'],
-        orig: {dest: 'dist/built-a.js', src: [value.files['dist/built-a.js']]},
+        orig: {dest: 'dist/built-a.js', src: [value.files['dist/built-a.js']]}
       },
       {
         dest: 'dist/built-b.js',
         src: ['src/file1.js', 'src/file2.js'],
-        orig: {dest: 'dist/built-b.js', src: flatten(value.files['dist/built-b.js'])},
-      },
+        orig: {dest: 'dist/built-b.js', src: flatten(value.files['dist/built-b.js'])}
+      }
     ];
     test.deepEqual(actual, expected, 'should normalize target: {files: {destTarget: srcStuff, ...}}.');
 
@@ -87,13 +87,13 @@ exports['task.normalizeMultiTaskFiles'] = {
       {
         dest: 'dist/built-a.js',
         src: [],
-        orig: {dest: Object.keys(value.files[0])[0], src: [value.files[0]['dist/built-a.js']]},
+        orig: {dest: Object.keys(value.files[0])[0], src: [value.files[0]['dist/built-a.js']]}
       },
       {
         dest: 'dist/built-b.js',
         src: ['src/file1.js', 'src/file2.js'],
-        orig: {dest: Object.keys(value.files[1])[0], src: flatten(value.files[1]['dist/built-b.js'])},
-      },
+        orig: {dest: Object.keys(value.files[1])[0], src: flatten(value.files[1]['dist/built-b.js'])}
+      }
     ];
     test.deepEqual(actual, expected, 'should normalize target: {files: [{destTarget: srcStuff}, ...]}.');
 
@@ -108,13 +108,13 @@ exports['task.normalizeMultiTaskFiles'] = {
       {
         dest: 'dist/built-a.js',
         src: ['src/file2.js'],
-        orig: value.files[0],
+        orig: value.files[0]
       },
       {
         dest: 'dist/built-b.js',
         src: ['src/file1.js', 'src/file2.js'],
-        orig: value.files[1],
-      },
+        orig: value.files[1]
+      }
     ];
     test.deepEqual(actual, expected, 'should normalize target: {files: [{src: srcStuff, dest: destStuff}, ...]}.');
 
@@ -131,15 +131,15 @@ exports['task.normalizeMultiTaskFiles'] = {
         src: ['src/file2.js'],
         foo: 123,
         bar: true,
-        orig: value.files[0],
+        orig: value.files[0]
       },
       {
         dest: 'dist/built-b.js',
         src: ['src/file1.js', 'src/file2.js'],
         foo: 456,
         bar: null,
-        orig: value.files[1],
-      },
+        orig: value.files[1]
+      }
     ];
     test.deepEqual(actual, expected, 'should propagate extra properties.');
 
@@ -151,22 +151,22 @@ exports['task.normalizeMultiTaskFiles'] = {
 
     value = {
       src: ['src/xxx*.js', 'src/yyy*.js'],
-      dest: 'dist/built.js',
+      dest: 'dist/built.js'
     };
     actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
     expected = [
       {
         dest: value.dest,
         src: [],
-        orig: value,
-      },
+        orig: value
+      }
     ];
     test.deepEqual(actual, expected, 'if nonull is not set, should not include non-matching patterns.');
 
     value = {
       src: ['src/xxx*.js', 'src/yyy*.js'],
       dest: 'dist/built.js',
-      nonull: true,
+      nonull: true
     };
     actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
     expected = [
@@ -174,8 +174,8 @@ exports['task.normalizeMultiTaskFiles'] = {
         dest: value.dest,
         src: value.src,
         nonull: true,
-        orig: value,
-      },
+        orig: value
+      }
     ];
     test.deepEqual(actual, expected, 'if nonull is set, should include non-matching patterns.');
     test.done();
@@ -187,45 +187,45 @@ exports['task.normalizeMultiTaskFiles'] = {
     value = {
       files: [
         {dest: 'dist/', src: ['src/file?.js'], expand: true},
-        {dest: 'dist/', src: ['file?.js'], expand: true, cwd: 'src'},
+        {dest: 'dist/', src: ['file?.js'], expand: true, cwd: 'src'}
       ]
     };
     actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
     expected = [
       {
         dest: 'dist/src/file1.js', src: ['src/file1.js'],
-        orig: value.files[0],
+        orig: value.files[0]
       },
       {
         dest: 'dist/src/file2.js', src: ['src/file2.js'],
-        orig: value.files[0],
+        orig: value.files[0]
       },
       {
         dest: 'dist/file1.js', src: ['src/file1.js'],
-        orig: value.files[1],
+        orig: value.files[1]
       },
       {
         dest: 'dist/file2.js', src: ['src/file2.js'],
-        orig: value.files[1],
-      },
+        orig: value.files[1]
+      }
     ];
     test.deepEqual(actual, expected, 'expand to file mapping, removing cwd from destination paths.');
 
     value = {
       files: [
-        {dest: 'dist/', src: ['src/file?.js'], expand: true, flatten: true},
+        {dest: 'dist/', src: ['src/file?.js'], expand: true, flatten: true}
       ]
     };
     actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
     expected = [
       {
         dest: 'dist/file1.js', src: ['src/file1.js'],
-        orig: value.files[0],
+        orig: value.files[0]
       },
       {
         dest: 'dist/file2.js', src: ['src/file2.js'],
-        orig: value.files[0],
-      },
+        orig: value.files[0]
+      }
     ];
     test.deepEqual(actual, expected, 'expand to file mapping, flattening destination paths.');
 
@@ -237,23 +237,23 @@ exports['task.normalizeMultiTaskFiles'] = {
           expand: true,
           rename: function(destBase, destPath) {
             return destBase + 'min/' + destPath.replace(/(\.js)$/, '.min$1');
-          },
-        },
+          }
+        }
       ]
     };
     actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
     expected = [
       {
         dest: 'dist/min/src/file1.min.js', src: ['src/file1.js'],
-        orig: value.files[0],
+        orig: value.files[0]
       },
       {
         dest: 'dist/min/src/file2.min.js', src: ['src/file2.js'],
-        orig: value.files[0],
-      },
+        orig: value.files[0]
+      }
     ];
     test.deepEqual(actual, expected, 'expand to file mapping, renaming files.');
 
     test.done();
-  },
+  }
 };

--- a/test/grunt/template_test.js
+++ b/test/grunt/template_test.js
@@ -43,5 +43,5 @@ exports['template'] = {
     test.equal(grunt.template.process('{%= baz %}', {data: obj, delimiters: 'custom'}), 'ab{% oops %de', 'should not explode.');
 
     test.done();
-  },
+  }
 };

--- a/test/grunt/util_test.js
+++ b/test/grunt/util_test.js
@@ -94,7 +94,7 @@ exports['util.spawn'] = {
     test.expect(6);
     grunt.util.spawn({
       cmd: process.execPath,
-      args: [ this.script, 0 ],
+      args: [ this.script, 0 ]
     }, function(err, result, code) {
       test.equals(err, null);
       test.equals(code, 0);
@@ -125,7 +125,7 @@ exports['util.spawn'] = {
     test.expect(7);
     grunt.util.spawn({
       cmd: process.execPath,
-      args: [ this.script, 123 ],
+      args: [ this.script, 123 ]
     }, function(err, result, code) {
       test.ok(err instanceof Error);
       test.equals(err.message, 'stderr');
@@ -156,7 +156,7 @@ exports['util.spawn'] = {
   'cmd not found': function(test) {
     test.expect(3);
     grunt.util.spawn({
-      cmd: 'nodewtfmisspelled',
+      cmd: 'nodewtfmisspelled'
     }, function(err, result, code) {
       test.ok(err instanceof Error);
       test.equals(code, 127);
@@ -181,7 +181,7 @@ exports['util.spawn'] = {
     test.expect(6);
     var win32 = process.platform === 'win32';
     grunt.util.spawn({
-      cmd: 'test\\fixtures\\exec' + (win32 ? '.cmd' : '.sh'),
+      cmd: 'test\\fixtures\\exec' + (win32 ? '.cmd' : '.sh')
     }, function(err, result, code) {
       test.equals(err, null);
       test.equals(code, 0);
@@ -197,7 +197,7 @@ exports['util.spawn'] = {
     var win32 = process.platform === 'win32';
     grunt.util.spawn({
       cmd: './exec' + (win32 ? '.cmd' : '.sh'),
-      opts: {cwd: 'test/fixtures'},
+      opts: {cwd: 'test/fixtures'}
     }, function(err, result, code) {
       test.equals(err, null);
       test.equals(code, 0);
@@ -212,7 +212,7 @@ exports['util.spawn'] = {
     test.expect(3);
     grunt.util.spawn({
       grunt: true,
-      args: [ '--gruntfile', 'test/fixtures/Gruntfile-print-text.js', 'print:foo' ],
+      args: [ '--gruntfile', 'test/fixtures/Gruntfile-print-text.js', 'print:foo' ]
     }, function(err, result, code) {
       test.equals(err, null);
       test.equals(code, 0);
@@ -225,7 +225,7 @@ exports['util.spawn'] = {
     grunt.util.spawn({
       grunt: true,
       args: [ '--gruntfile', 'Gruntfile-print-text.js', 'print:foo' ],
-      opts: {cwd: 'test/fixtures'},
+      opts: {cwd: 'test/fixtures'}
     }, function(err, result, code) {
       test.equals(err, null);
       test.equals(code, 0);
@@ -242,7 +242,7 @@ exports['util.spawn'] = {
     var child = grunt.util.spawn({
       cmd: process.execPath,
       args: [ this.script, 0 ],
-      opts: {stdio: [null, stdout, stderr]},
+      opts: {stdio: [null, stdout, stderr]}
     }, function(err, result, code) {
       test.equals(code, 0);
       test.equals(String(fs.readFileSync(stdoutFile.path)), 'stdout\n', 'Child process stdout should have been captured via custom stream.');
@@ -254,7 +254,7 @@ exports['util.spawn'] = {
     });
     test.ok(!child.stdout, 'child should not have a stdout property.');
     test.ok(!child.stderr, 'child should not have a stderr property.');
-  },
+  }
 };
 
 exports['util.underscore.string'] = function(test) {


### PR DESCRIPTION
While I was looking at the test suite I noticed some minor syntax cleanup I could do. This pull request is for the removal of superfluous commas in `/test/grunt/`.
