### PR TITLE
Improve usability of child process's stream interface for util.spawn

### DIFF
--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -147,16 +147,16 @@ util.spawn = function(opts, done) {
   } else {
     // On Windows, child_process.spawn will only file .exe files in the PATH,
     // not other executable types (grunt issue #155).
-    try {
-      if (!pathSeparatorRe.test(opts.cmd)) {
-        // Only use which if cmd has no path component.
+    if (!pathSeparatorRe.test(opts.cmd)) {
+      // Only use which if cmd has no path component.
+      try {
         cmd = which(opts.cmd);
-      } else {
-        cmd = opts.cmd.replace(pathSeparatorRe, path.sep);
+      } catch (err) {
+        // Will fail later on when spawn is called, but that's expected.
+        cmd = opts.cmd;
       }
-    } catch (err) {
-      callDone(127, '', String(err));
-      return;
+    } else {
+      cmd = opts.cmd.replace(pathSeparatorRe, path.sep);
     }
     args = opts.args;
   }
@@ -171,7 +171,9 @@ util.spawn = function(opts, done) {
     child.stderr.on('data', function(buf) { stderr += buf; });
   }
   child.on('close', function(code) {
-    callDone(code, stdout, stderr);
+    if (done) {
+      callDone(code, stdout, stderr);
+    }
   });
   return child;
 };


### PR DESCRIPTION
Right now, if the command passed to `util.spawn` isn't found, `undefined` is returned and the `done` callback is invoked. This makes it impossible to rely entirely on the stream interface of the spawned child process. For example, I couldn't do the following:

``` javascript
var child = grunt.spawn('notacommand');

child.stdout.on('data', function(d) { grunt.log.write(d); });
child.stderr.on('data', function(d) { grunt.log.error(d); });
```

Instead, I'd have to do something like:

``` javascript
var child = grunt.spawn('notacommand', function(error, result, code) {
  code !== 0 && grunt.log.error(result.stderr);
});

child && child.stdout.on('data', function(d) { grunt.log.write(d); });
child && child.stderr.on('data', function(d) { grunt.log.error(d); });
```

This pull request adds support for the former example. The downside to this change is that the error message for when a command is not found is not as descriptive as it previously was. If this is a sticking point for this pull request, I'll address the regression.

One other note – I didn't test this out on Windows.
