### PR TITLE
refactored grunt.package to be resolved via require()

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -26,7 +26,7 @@ var util = gRequire('util');
 gRequire('template');
 gRequire('event');
 var fail = gRequire('fail');
-var file = gRequire('file');
+gRequire('file');
 var option = gRequire('option');
 var config = gRequire('config');
 var task = gRequire('task');
@@ -36,7 +36,7 @@ gRequire('cli');
 var verbose = grunt.verbose = log.verbose;
 
 // Expose some grunt metadata.
-grunt.package = file.readJSON(path.join(__dirname, '../package.json'));
+grunt.package = require('../package.json');
 grunt.version = grunt.package.version;
 
 // Expose specific grunt lib methods on grunt.


### PR DESCRIPTION
grunt.package and grunt.version are now resolved by using require's [ability to pull in package.json](https://github.com/joyent/node/issues/1357). As require() is independent of the working directory, you dont need to use `__dirname` either. 
