### PR TITLE
Calling grunt.fatal must exit the process with a non-zero exit code

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -54,7 +54,7 @@ function dumpStack(e) {
 fail.fatal = function(e, errcode) {
   writeln(e, 'fatal');
   dumpStack(e);
-  process.exit(typeof errcode === 'number' ? errcode : fail.code.GENERAL_ERROR);
+  process.exit(typeof errcode === 'number' ? errcode : fail.code.FATAL_ERROR);
 };
 
 // Keep track of error and warning counts.


### PR DESCRIPTION
Calling `grunt.fatal` must exit the process with a non-zero exit code when no errcode is provided.
It's not the case currently because `fail.code.GENERAL_ERROR` is `undefined`.
`grunt.fatal` should probably use `fail.code.FATAL_ERROR` instead.
