### PR TITLE
Fixing the exit process

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -54,7 +54,7 @@ function dumpStack(e) {
 fail.fatal = function(e, errcode) {
   writeln(e, 'fatal');
   dumpStack(e);
-  process.exit(typeof errcode === 'number' ? errcode : fail.code.GENERAL_ERROR);
+  grunt.util.exit(typeof errcode === 'number' ? errcode : fail.code.FATAL_ERROR);
 };
 
 // Keep track of error and warning counts.
@@ -70,7 +70,7 @@ fail.warn = function(e, errcode) {
   if (!grunt.option('force')) {
     dumpStack(e);
     grunt.log.writeln().fail('Aborted due to warnings.');
-    process.exit(typeof errcode === 'number' ? errcode : fail.code.WARNING);
+    grunt.util.exit(typeof errcode === 'number' ? errcode : fail.code.WARNING);
   }
 };
 

--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -22,7 +22,9 @@ util.task = require('../util/task');
 util.namespace = require('../util/namespace');
 // Use instead of process.exit to ensure stdout/stderr are flushed
 // before exiting in Windows (Tested in Node.js v0.8.7)
-util.exit = require('../util/exit').exit;
+var exitModule = require('../util/exit');
+util.exit = exitModule.exit;
+util.hasExited = exitModule.hasExited;
 
 // External libs.
 util.hooker = require('hooker');

--- a/lib/util/exit.js
+++ b/lib/util/exit.js
@@ -9,18 +9,45 @@
 
 'use strict';
 
+var exitCalled = false;
+var storedExitCode = 0;
+
 // This seems to be required in Windows (as of Node.js 0.8.7) to ensure that
 // stdout/stderr are flushed before the process exits.
 
 // https://gist.github.com/3427148
 // https://gist.github.com/3427357
+// Note that _pendingWriteReqs is not in the public API of Node.js.
+// The drain event has to be used instead.
 
-exports.exit = function exit(exitCode) {
-  if (process.stdout._pendingWriteReqs || process.stderr._pendingWriteReqs) {
-    process.nextTick(function() {
-      exit(exitCode);
-    });
-  } else {
-    process.exit(exitCode);
+var streamFinished = function (stream, callback) {
+  // Writes an empty string to check the state of the buffer:
+  if (stream.write("")) {
+    return true;
   }
+  stream.once('drain', callback);
+  return false;
+};
+
+var exit = function () {
+  var ok = true;
+  ok = ok && streamFinished(process.stdout, exit);
+  ok = ok && streamFinished(process.stderr, exit);
+  if (ok) {
+    process.exit(storedExitCode);
+  }
+};
+
+// Exits the process, making sure the stdout and stderr streams have fully received their content.
+exports.exit = function (exitCode) {
+  var firstExit = !exitCalled;
+  if (firstExit) {
+    exitCalled = true;
+    storedExitCode = exitCode;
+  }
+  exit();
+};
+
+exports.hasExited = function () {
+  return exitCalled;
 };

--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -11,6 +11,8 @@
 
   'use strict';
 
+  var exitModule = require('./exit');
+
   // Construct-o-rama.
   function Task() {
     // Information about the currently-running task.
@@ -191,6 +193,10 @@
 
     // Update the internal status object and run the next task.
     var complete = function(success) {
+      if (exitModule.hasExited()) {
+        // do nothing if grunt.util.exit was called previously
+        return;
+      }
       var err = null;
       if (success === false) {
         // Since false was passed, the task failed generically.


### PR DESCRIPTION
This pull request is a step forward in order to solve #664.

Under some environments (especially cygwin on Windows, but also when piping grunt's output to another program), exiting the process too quickly with `process.exit` may hide some errors or warnings logged with console.log but not yet displayed. This problem will apparently not be fixed in node.js itself (note that there was a discussion about this a long time ago [here](https://groups.google.com/forum/?fromgroups=#!topic/nodejs-dev/Tj_HNQbvtZs) and nothing changed).

In Grunt, a `grunt.util.exit` method already exists, which waits for the output to be properly processed before exiting. However, there are some places where `process.exit` is still used. Moreover `grunt.util.exit` is using properties which are not part of the public API of node.js.

This pull request fixes those issues and adds a `grunt.util.hasExited` method which returns whether `grunt.util.exit` was called. This new method is now called after a task is completed, before trying to do anything more, so that no new task is executed after calling `grunt.util.exit`.

Please consider integrating this pull request so that Grunt becomes really usable for users who face this issue. Otherwise, it is really painful when errors seem to have probably happened but no detail is displayed.

Thank you in advance. I also take this opportunity to thank you for the good job you have already done with Grunt.
