### PR TITLE
Prevent unexpected error from calling log.wraptext on undefined

### DIFF
--- a/lib/grunt/log.js
+++ b/lib/grunt/log.js
@@ -202,6 +202,9 @@ log.uncolor = function(str) {
 
 // Word-wrap text to a given width, permitting ANSI color codes.
 log.wraptext = function(width, text) {
+  // safeguard from trying to wrap empty or undefined text
+  if(!text) { return ''; }
+
   // notes to self:
   // grab 1st character or ansi code from string
   // if ansi code, add to array and save for later, strip from front of string

--- a/test/grunt/log_test.js
+++ b/test/grunt/log_test.js
@@ -38,7 +38,7 @@ exports['log'] = {
     test.done();
   },
   'error': function(test) {
-    test.expect(4);
+    test.expect(5);
 
     stdoutEqual(test, function() { grunt.log.error(); }, 'ERROR\n');
     stdoutEqual(test, function() { grunt.log.error('foo'); }, '>> foo\n');
@@ -48,12 +48,13 @@ exports['log'] = {
     }, '>> ' + grunt.util._.repeat('foo', 19, ' ') + '\n' +
       '>> ' + grunt.util._.repeat('foo', 11, ' ') + '\n');
 
+    stdoutEqual(test, function() { grunt.log.errorlns(); }, 'ERROR\n');
     stdoutEqual(test, function() { grunt.log.fail('foo'); }, 'foo\n');
 
     test.done();
   },
   'ok': function(test) {
-    test.expect(4);
+    test.expect(5);
 
     stdoutEqual(test, function() { grunt.log.ok(); }, 'OK\n');
     stdoutEqual(test, function() { grunt.log.ok('foo'); }, '>> foo\n');
@@ -63,6 +64,7 @@ exports['log'] = {
     }, '>> ' + grunt.util._.repeat('foo', 19, ' ') + '\n' +
       '>> ' + grunt.util._.repeat('foo', 11, ' ') + '\n');
 
+    stdoutEqual(test, function() { grunt.log.oklns(); }, 'OK\n');
     stdoutEqual(test, function() { grunt.log.success('foo'); }, 'foo\n');
 
     test.done();


### PR DESCRIPTION
Previously internal calls to `grunt.log.wraptext(77, undefined)` would throw an uncaught error. This was due to the `text.match` call. Now, if `grunt.log.wraptext` is called with `undefined` or a string of `length === 0`, `''` is returned. This also make calls to `grunt.log.*lns()` print the expected status text. For example `grunt.log.oklns()` will output `OK`.

Added a check to ensure text is _something_ significant (ie: not of length 0 or undefined), modified tests for this functionality.
