### PR TITLE
Use grunt-release for automating Grunt releases with Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-release');
 
   // "npm test" runs these tasks
   grunt.registerTask('test', ['jshint', 'nodeunit', 'subgrunt']);

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-nodeunit": "~0.1.2",
     "grunt-contrib-watch": "~0.2.0",
-    "difflet": "~0.2.3"
+    "difflet": "~0.2.3",
+    "grunt-release": "~0.3.1"
   }
 }


### PR DESCRIPTION
I'm jumping in to help on the development of Grunt and the 30 or so contrib plugins. When I was working on the Angular grunt build I noticed that Grunt and these libs sometimes hadn't pushed their latest changes to npm, or bumped the version, or created a git tag, etc. Which is understandable, the release process for a node lib is pretty tedious: 
1. bump the version in your package.json file.
2. stage the package.json file's change.
3. commit that change with a message like "release 0.6.22".
4. create a new git tag for the release.
5. push the changes out to github.
6. also push the new tag out to github.
7. publish the new version to npm.

It's easy to forget steps (I do all the time). Luckily there's this cool new tool you may have heard of, named Grunt, that lets us automate things like this. I wrote a [grunt-release](https://github.com/geddesign/grunt-release) that does all these steps automatically with one command:

`grunt release`
      or
`grunt release:minor`
      or
`grunt release:major`

I suggest we add this to the Grunt project and all the contrib plugins (I have push access to those, so I can do that part). Then we can `grunt release` all the things.
