### PR TITLE
Fix bug in file.expand/recurse when options.cwd is not set in Node 0.10.0

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -114,7 +114,7 @@ file.expand = function() {
   // Filter result set?
   if (options.filter) {
     matches = matches.filter(function(filepath) {
-      filepath = path.join(options.cwd, filepath);
+      filepath = path.join(options.cwd || '', filepath);
       try {
         if (typeof options.filter === 'function') {
           return options.filter(filepath);
@@ -204,7 +204,7 @@ file.recurse = function recurse(rootdir, callback, subdir) {
   fs.readdirSync(abspath).forEach(function(filename) {
     var filepath = path.join(abspath, filename);
     if (fs.statSync(filepath).isDirectory()) {
-      recurse(rootdir, callback, unixifyPath(path.join(subdir, filename)));
+      recurse(rootdir, callback, unixifyPath(path.join(subdir || '', filename || '')));
     } else {
       callback(unixifyPath(filepath), rootdir, subdir, filename);
     }


### PR DESCRIPTION
path.join arguments must be strings
