### PR TITLE
Fix path.join thrown errors with expandMapping rename

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -137,7 +137,7 @@ var pathSeparatorRe = /[\/\\]/g;
 file.expandMapping = function(patterns, destBase, options) {
   options = grunt.util._.defaults({}, options, {
     rename: function(destBase, destPath) {
-      return path.join(destBase, destPath);
+      return path.join(destBase || '', destPath);
     }
   });
   var files = [];


### PR DESCRIPTION
This is the only other `path` error I found. Hits when `grunt-contrib-compress` when `cwd` and `expand` are set.
