### PR TITLE
Fixing Issue #615 (grunt.file.copy preserves permissions)

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -296,6 +296,19 @@ file.write = function(filepath, contents, options) {
 // Read a file, optionally processing its content, then write the output.
 file.copy = function(srcpath, destpath, options) {
   if (!options) { options = {}; }
+  
+  // preserve permissions unless explicitly asked not to.
+  var preservePermissions = !(options.preservePermissions && options.preservePermissions === false);
+  // we don't care about permissions if we don't write
+  if (grunt.option('no-write')) {
+    preservePermissions = false;
+  }
+
+  var stat;
+  if (preservePermissions) {
+    stat = fs.statSync(srcpath);
+  }
+
   // If a process function was specified, and noProcess isn't true or doesn't
   // match the srcpath, process the file's source.
   var process = options.process && options.noProcess !== true &&
@@ -320,6 +333,18 @@ file.copy = function(srcpath, destpath, options) {
     grunt.verbose.writeln('Write aborted.');
   } else {
     file.write(destpath, contents, readWriteOptions);
+    if (preservePermissions) {
+      try {
+        fs.chownSync(destpath, stat.uid, stat.gid);
+      } catch(e) {
+          throw grunt.util.error('Error while setting owner and group of "' + destpath + '" file.', e);
+      }
+      try {
+        fs.chmodSync(destpath, stat.mode);
+      } catch(e) {
+          throw grunt.util.error('Error setting permissions of "' + destpath + '" file.', e);
+      }
+    }
   }
 };
 

--- a/test/fixtures/chmod676.txt
+++ b/test/fixtures/chmod676.txt
@@ -1,0 +1,1 @@
+I have strange permissions, dude

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -464,6 +464,25 @@ exports['file'] = {
     test.equal(grunt.file.exists(filepath), false, 'file should NOT be created if --no-write was specified.');
     test.done();
   },
+  'copy permissions (on a platform that supports it)': function(test) {
+    var srcstat = fs.statSync('test/fixtures/chmod676.txt');
+    if ((srcstat.mode & 0x1ff).toString(8) === '676') { // lint doesn't like octal literals
+      test.expect(3);
+      var tmpfile;
+      tmpfile = new Tempfile();
+      grunt.file.copy('test/fixtures/chmod676.txt', tmpfile.path);
+      var deststat = fs.statSync(tmpfile.path);
+      test.equal((srcstat.mode & 0x1ff).toString(8), (deststat.mode & 0x1ff).toString(8), 'file mode should be preserved by default');
+      test.equal(srcstat.uid, deststat.uid, 'file owner should be preserved by default');
+      test.equal(srcstat.gid, deststat.gid, 'file group should be preserved by default');
+      tmpfile.unlinkSync();
+    } else {
+      test.expect(0);
+      process.stderr.write("(platform does not support file permissions. mode of chmod676.txt is " + (srcstat.mode & 0x1ff).toString(8) + ")");
+    }
+    test.done();
+  },
+
   'copy and process': function(test) {
     test.expect(13);
     var tmpfile;


### PR DESCRIPTION
unless preservePermissons is explicitly set to false in the options, file.copy will now copy owner, group and mode from the source to the destination.
