### PR TITLE
Use os.EOL instead of plain new line literal.

### DIFF
--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -4,7 +4,6 @@ var grunt = require('../../lib/grunt');
 
 var fs = require('fs');
 var path = require('path');
-var os = require('os');
 
 var Tempfile = require('temporary/lib/file');
 var Tempdir = require('temporary/lib/dir');
@@ -360,7 +359,7 @@ exports['file'] = {
   setUp: function(done) {
     this.defaultEncoding = grunt.file.defaultEncoding;
     grunt.file.defaultEncoding = 'utf8';
-    this.string = 'Ação é isso aí' + os.EOL;
+    this.string = 'Ação é isso aí' + grunt.util.linefeed;
     this.object = {foo: 'Ação é isso aí', bar: ['ømg', 'pønies']};
     this.writeOption = grunt.option('write');
     done();


### PR DESCRIPTION
Some tests fail on Windows because of the usage of the "\n" literal when checking content of files. These failures can be fixed by using os.EOL instead of the literal.

Following, affected tests.

```
>> file - read
>> Message: file should be read as utf8 by default.
>> Error: 'Ação é isso aí\r\n' === 'Ação é isso aí\n'
>> at Object.exports.file.read (test\grunt\file_test.js:374:10)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - read
>> Message: file should be read using the specified encoding.
>> Error: 'Ação é isso aí\r\n' === 'Ação é isso aí\n'
>> at Object.exports.file.read (test\grunt\file_test.js:375:10)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - read
>> Message: changing the default encoding should work.
>> Error: 'Ação é isso aí\r\n' === 'Ação é isso aí\n'
>> at Object.exports.file.read (test\grunt\file_test.js:380:10)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - copy and process
>> Message: file should be saved as properly encoded processed string.
>> Error: 'føøAção é isso aí\r\nbår' == 'føøAção é isso aí\nbår'
>> at Object.exports.file.copy and process (test\grunt\file_test.js:479:10)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - copy and process
>> Message: file should be saved as properly encoded processed string.
>> Error: 'føøAção é isso aí\r\nbår' == 'føøAção é isso aí\nbår'
>> at Object.exports.file.copy and process (test\grunt\file_test.js:491:10)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - copy and process
>> Message: file should be saved as the buffer returned by process.
>> Error: 'føøAção é isso aí\r\nbår' == 'føøAção é isso aí\nbår'
>> at Object.exports.file.copy and process (test\grunt\file_test.js:502:10)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - copy and process
>> Message: file should be saved as properly encoded processed string.
>> Error: 'føøAção é isso aí\r\nbår' == 'føøAção é isso aí\nbår'
>> at Object.exports.file.copy and process (test\grunt\file_test.js:514:10)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - copy and process, noprocess
>> Message: file should not have been processed.
>> Error: 'Ação é isso aí\r\n' == 'Ação é isso aí\n'
>> at Object.exports.file.copy and process, noprocess (test\grunt\file_test.js:536:10)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - copy and process, noprocess
>> Message: file should have been processed.
>> Error: 'føøAção é isso aí\r\nbår' == 'føøAção é isso aí\nbår'
>> at Object.<anonymous> (test\grunt\file_test.js:550:14)
>> at Array.forEach (native)
>> at Object.exports.file.copy and process, noprocess (test\grunt\file_test.js:539:48)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - copy and process, noprocess
>> Message: file should not have been processed.
>> Error: 'Ação é isso aí\r\n' == 'Ação é isso aí\n'
>> at Object.<anonymous> (test\grunt\file_test.js:552:14)
>> at Array.forEach (native)
>> at Object.exports.file.copy and process, noprocess (test\grunt\file_test.js:539:48)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)

>> file - copy and process, noprocess
>> Message: file should not have been processed.
>> Error: 'Ação é isso aí\r\n' == 'Ação é isso aí\n'
>> at Object.<anonymous> (test\grunt\file_test.js:552:14)
>> at Array.forEach (native)
>> at Object.exports.file.copy and process, noprocess (test\grunt\file_test.js:539:48)
>> at Object.exports.file.setUp (test\grunt\file_test.js:365:5)
```
