### PR TITLE
Output task options in verbose mode

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -64,7 +64,9 @@ task.registerTask = function(name) {
       var args = [{}].concat(grunt.util.toArray(arguments)).concat([
         grunt.config([name, 'options'])
       ]);
-      return grunt.util._.extend.apply(null, args);
+      var options = grunt.util._.extend.apply(null, args);
+      grunt.verbose.writeflags(options, 'Options');
+      return options;
     };
     // If this task was an alias or a multi task called without a target,
     // only log if in verbose mode.
@@ -236,7 +238,9 @@ task.registerMultiTask = function(name, info, fn) {
         grunt.config([name, 'options']),
         grunt.util.kindOf(targetObj) === 'object' ? targetObj.options : {}
       ]);
-      return grunt.util._.extend.apply(null, args);
+      var options = grunt.util._.extend.apply(null, args);
+      grunt.verbose.writeflags(options, 'Options');
+      return options;
     };
     // Expose data on `this` (as well as task.current).
     this.data = grunt.config([name, target]);


### PR DESCRIPTION
Contrib tasks currently include `grunt.verbose.writeflags(options, 'Options');`. Now that we have standardized `this.options()` it would be nice if grunt could print out the options automagically in verbose mode.

![Screen Shot 2013-04-03 at 00 17 17](https://f.cloud.github.com/assets/170270/335739/2c1b067e-9c95-11e2-8192-6a9318ce3759.png)
