### PR TITLE
extension is after _last_ period only

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -151,7 +151,7 @@ file.expandMapping = function(patterns, destBase, options) {
     }
     // Change the extension?
     if (options.ext) {
-      destPath = destPath.replace(/(\.[^\/]*)?$/, options.ext);
+      destPath = destPath.replace(/(\.[^\/.]*)?$/, options.ext);
     }
     // Generate destination filename.
     var dest = options.rename(destBase, destPath, options);


### PR DESCRIPTION
in file.expandMapping, fix destPath replace such that only the extension
is replaced, not anything after the first '.' of the last path segment.

In other words, if the source file is 'my/dir/path/test.single.js', only
the final '.js' should be considered the extension, not '.single.js',
and only that should be replaced.
