### PR TITLE
Add grunt logo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Grunt: The JavaScript Task Runner [![Build Status](https://secure.travis-ci.org/gruntjs/grunt.png?branch=master)](http://travis-ci.org/gruntjs/grunt)
 
+<img align="right" height="260" src="http://gruntjs.com/img/grunt-logo-no-wordmark.svg">
+
+
 ### Documentation
 
 Visit the [gruntjs.com](http://gruntjs.com/) website for all the things.


### PR DESCRIPTION
Would look nice to have to logo in the readme, as seen here: https://github.com/sindresorhus/grunt/tree/readme-logo

GitHub supports SVG in readme's a long as it comes with the right mime type, which GitHub of course not sends, so needs to be hosted on the server.

_I will update the svg url if this is greenlit_
