### PR TITLE
Update coffee-script dependency to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "async": "~0.1.22",
-    "coffee-script": "~1.3.3",
+    "coffee-script": "~1.6.2",
     "colors": "~0.6.0-1",
     "dateformat": "1.0.2-1.2.3",
     "eventemitter2": "~0.4.9",


### PR DESCRIPTION
The old coffee-script version has a bug that prevents grunt from working with `Gruntfile.coffee` files in windows.
