### PR TITLE
Added convinence method to load grunt tasks from package

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -49,6 +49,7 @@ gExpose(task, 'registerInitTask');
 gExpose(task, 'renameTask');
 gExpose(task, 'loadTasks');
 gExpose(task, 'loadNpmTasks');
+gExpose(task, 'loadTasksFromPackage');
 gExpose(config, 'init', 'initConfig');
 gExpose(fail, 'warn');
 gExpose(fail, 'fatal');

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -398,6 +398,24 @@ task.loadNpmTasks = function(name) {
   }
 };
 
+// Loads grunt tasks from Package.json
+// Shortcut for calling grunt.loadNPMTasks multiple times
+task.loadTasksFromPackage = function(){
+  var root = path.resolve('.');
+  var pkgfile = path.join(root, 'package.json');
+  if (!grunt.file.exists(pkgfile)){
+    grunt.log.error('Could not find package.json. Does package.json exist?');
+  } else {
+    var pkg =  grunt.file.readJSON(pkgfile);
+    for (var key in pkg.devDependencies){
+      if (key !== 'grunt' && key.indexOf('grunt') === 0) {
+        // Load only dev dependencies that start with grunt. Ignore grunt itself as a dev dependency
+        task.loadNpmTasks(key);
+      }
+    }
+  }
+}
+
 // Initialize tasks.
 task.init = function(tasks, options) {
   if (!options) { options = {}; }


### PR DESCRIPTION
Most Gruntfile.js use `grunt.loadNpmTasks(...)` multiple times to load the devDependencies described in the package.json. Also during development, users currently have to do `npm install --save-dev` and then add that task to `GruntFile.js`. 
This task tries to make it easier for most cases. 
This is a convinence method to automatically load all the grunt `devDependencies` defined in `package.json`. 
