### PR TITLE
Add the Roadmap to the main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ You can find the grunt team in [#grunt on irc.freenode.net](irc://irc.freenode.n
 
 ### Release History
 See the [CHANGELOG](CHANGELOG).
+
+### Roadmap
+See the [Roadmap](https://github.com/gruntjs/grunt/wiki/Roadmap).


### PR DESCRIPTION
The roadmap currently is difficult to find. Making it more discoverable may reduce feature request issues for things that are already planned.
