### PR TITLE
Update async dependency to ~0.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "tool"
   ],
   "dependencies": {
-    "async": "~0.1.22",
     "coffee-script": "~1.3.3",
     "colors": "~0.6.0-1",
     "dateformat": "1.0.2-1.2.3",
@@ -59,7 +58,8 @@
     "lodash": "~0.9.0",
     "underscore.string": "~2.2.0rc",
     "which": "~1.0.5",
-    "js-yaml": "~2.0.2"
+    "js-yaml": "~2.0.2",
+    "async": "~0.2.8"
   },
   "devDependencies": {
     "temporary": "~0.0.4",


### PR DESCRIPTION
Grunt currently depends on async ~0.1.22, while async is currently on 0.2.8. This commit updates the dependency.

Solves issue #778
