### PR TITLE
Allow gruntcollections to contain tasks

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -386,7 +386,12 @@ task.loadNpmTasks = function(name) {
       }
     });
     loadTaskDepth--;
-    return;
+
+    // A collection might define its own tasks. fall through to load them if
+    // the 'gruntplugin' keyword is seen.
+    if (pkg.keywords.indexOf('gruntplugin') === -1) {
+      return;
+    }
   }
 
   // Process task plugins.


### PR DESCRIPTION
If the 'gruntcollection' keyword is seen, after loading all required
tasks, check for the 'gruntplugin' keyword. If seen, try and load tasks
from the current module as well.
