### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "coffee-script": "~1.3.3",
     "colors": "~0.6.0-1",
     "dateformat": "1.0.2-1.2.3",
-    "eventemitter2": "~0.4.9",
+    "eventemitter2": "~0.4.11",
     "findup-sync": "~0.1.0",
     "glob": "~3.1.21",
     "hooker": "~0.2.3",


### PR DESCRIPTION
Newest npm does not accept package.json "repositories" in plural and throws a warning. Eventemitter2 fixed this in version 0.4.11. As eventemitter is a dependency of grunt, calling npm install will show a warning for this dependency. Upgrading the dependency to version 0.4.11 should fix this.
