### PR TITLE
removing splitArgs

### DIFF
--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -109,38 +109,18 @@
     return Array.isArray(args[0]) ? args[0] : [].slice.call(args);
   };
 
-  // Split a colon-delimited string into an array, unescaping (but not
-  // splitting on) any \: escaped colons.
-  Task.prototype.splitArgs = function(str) {
-    if (!str) { return []; }
-    // Store placeholder for \\ followed by \:
-    str = str.replace(/\\\\/g, '\uFFFF').replace(/\\:/g, '\uFFFE');
-    // Split on :
-    return str.split(':').map(function(s) {
-      // Restore place-held : followed by \\
-      return s.replace(/\uFFFE/g, ':').replace(/\uFFFF/g, '\\');
-    });
-  };
-
   // Given a task name, determine which actual task will be called, and what
   // arguments will be passed into the task callback. "foo" -> task "foo", no
-  // args. "foo:bar:baz" -> task "foo:bar:baz" with no args (if "foo:bar:baz"
-  // task exists), otherwise task "foo:bar" with arg "baz" (if "foo:bar" task
-  // exists), otherwise task "foo" with args "bar" and "baz".
+  // args. "foo:bar:baz" -> task "foo " with args "bar" and "baz".Task is
+  // delimited from args by colon. 
+
   Task.prototype._taskPlusArgs = function(name) {
     // Get task name / argument parts.
-    var parts = this.splitArgs(name);
-    // Start from the end, not the beginning!
-    var i = parts.length;
-    var task;
-    do {
-      // Get a task.
-      task = this._tasks[parts.slice(0, i).join(':')];
-      // If the task doesn't exist, decrement `i`, and if `i` is greater than
-      // 0, repeat.
-    } while (!task && --i > 0);
+    var parts = name.split(":");
+    // Check the task
+    var task = this._tasks[parts[0]];
     // Just the args.
-    var args = parts.slice(i);
+    var args = parts.slice(1);
     // Maybe you want to use them as flags instead of as positional args?
     var flags = {};
     args.forEach(function(arg) { flags[arg] = true; });

--- a/test/util/task_test.js
+++ b/test/util/task_test.js
@@ -214,24 +214,17 @@ exports['Tasks'] = {
           ['a:x:c',             1,  'a',      'x',        'c'],
           ['a:b ',              1,  'a',      'b ',       undefined],
           ['a: b:c',            1,  'a',      ' b',       'c'],
-          ['a:x\\:y:\\:z\\:',   1,  'a',      'x:y',      ':z:'],
+          
 
-          ['a:b',               2,  'a:b',    undefined,  undefined],
-          ['a:b:x',             2,  'a:b',    'x',        undefined],
-          ['a:b:x:y',           2,  'a:b',    'x',        'y'],
-          ['a:b:c ',            2,  'a:b',    'c ',       undefined],
-          ['a:b:x\\:y:\\:z\\:', 2,  'a:b',    'x:y',      ':z:'],
-
-          ['a:b:c',             3,  'a:b:c',  undefined,  undefined],
-          ['a:b:c: d',          3,  'a:b:c',  ' d',       undefined],
-        ], 'Named tasks should be called as-specified if possible, and arguments should be passed properly.');
+          ['a:b',               1,  'a',      'b',        undefined],
+          ['a:b:x',             1,  'a',      'b',        'x'],          
+        ], 'Task is must be delimited by colon from args');
         test.done();
       }
     });
     task.run(
-      'a',  'a:x', 'a:x:c', 'a:b ', 'a: b:c', 'a:x\\:y:\\:z\\:',
-      'a:b', 'a:b:x', 'a:b:x:y', 'a:b:c ', 'a:b:x\\:y:\\:z\\:',
-      'a:b:c', 'a:b:c: d'
+      'a',  'a:x', 'a:x:c', 'a:b ', 'a: b:c',
+      'a:b', 'a:b:x'   
     ).start();
   },
   'Task#run (nested tasks, queue order)': function(test) {
@@ -438,27 +431,6 @@ exports['Task#parseArgs'] = {
   'nothing': function(test) {
     test.expect(1);
     test.deepEqual(this.parseTest(), [], 'should return an empty array if nothing passed.');
-    test.done();
-  }
-};
-
-exports['Task#splitArgs'] = {
-  setUp: function(done) {
-    this.task = requireTask().create();
-    done();
-  },
-  'arguments': function(test) {
-    test.expect(9);
-    var task = this.task;
-    test.deepEqual(task.splitArgs(), [], 'missing items = empty array.');
-    test.deepEqual(task.splitArgs(''), [], 'missing items = empty array.');
-    test.deepEqual(task.splitArgs('a'), ['a'], 'single item should be parsed.');
-    test.deepEqual(task.splitArgs('a:b:c'), ['a', 'b', 'c'], 'mutliple items should be parsed.');
-    test.deepEqual(task.splitArgs('a::c'), ['a', '', 'c'], 'missing items should be parsed.');
-    test.deepEqual(task.splitArgs('::'), ['', '', ''], 'missing items should be parsed.');
-    test.deepEqual(task.splitArgs('\\:a:\\:b\\::c\\:'), [':a', ':b:', 'c:'], 'escaped colons should be unescaped.');
-    test.deepEqual(task.splitArgs('a\\\\:b\\\\:c'), ['a\\', 'b\\', 'c'], 'escaped backslashes should not be parsed.');
-    test.deepEqual(task.splitArgs('\\:a\\\\:\\\\\\:b\\:\\\\:c\\\\\\:\\\\'), [':a\\', '\\:b:\\', 'c\\:\\'], 'please avoid doing this, ok?');
     test.done();
   }
 };


### PR DESCRIPTION
Obviously , tasks must be delimited by colon from arguments ,
 and taskName don't need to have colon itself. 
<code>task : args:other_args:etc_args , </code>
but(!) no
 <code>Some:Not:Readable:task :args</code>
So , it will be more lightweight code in lib/util/tasks.js 
and taskNames will be more readable.
