### PR TITLE
Add feature to auto-load grunt plugins & collections from Npm modules.

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -49,6 +49,7 @@ gExpose(task, 'registerInitTask');
 gExpose(task, 'renameTask');
 gExpose(task, 'loadTasks');
 gExpose(task, 'loadNpmTasks');
+gExpose(task, 'autoloadNpmTasks');
 gExpose(config, 'init', 'initConfig');
 gExpose(fail, 'warn');
 gExpose(fail, 'fatal');

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -13,6 +13,7 @@ var grunt = require('../grunt');
 
 // Nodejs libs.
 var path = require('path');
+var fs = require('fs');
 
 // Extend generic "task" util lib.
 var parent = grunt.util.task.create();
@@ -360,6 +361,74 @@ task.loadTasks = function(tasksdir) {
   } else {
     grunt.log.error('Tasks directory "' + tasksdir + '" not found.');
   }
+};
+
+// Detect all Npm modules that are Grunt plugins or collections (installed
+// relative to the base dir).
+task.detectNpmTasks = function(root) {
+  var msg, npmdir;
+  // Use local Npm directory as root by default.
+  if (grunt.util.kindOf(root) === 'undefined') {
+    root = path.resolve('node_modules');
+  }
+  // Find the nearest Npm directory, relative to root.
+  npmdir = grunt.file.findup('node_modules', {
+    cwd: root,
+    nocase: true
+  });
+  msg = 'Detecting Npm tasks from "' + root + '".';
+  grunt.verbose.subhead(msg);
+  // A list of modules to be loaded.
+  var modulesToLoad = [];
+  // Iterate through files in Npm directory. 
+  var files = fs.readdirSync(npmdir);
+  files.forEach(function(basename) {
+    var absolutePath = path.join(root, basename);
+    // Verify this file is a directory.
+    if (! grunt.file.isDir(absolutePath)) {
+      return;
+    }
+    // Read the "package.json" file, if it exists.
+    var pkgfile = path.join(absolutePath, 'package.json');
+    var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
+    // Whether to skip this module directory (assume yes).
+    var skip = true;
+    // Is this a node module, with keywords?
+    if (pkg.keywords) {
+      // Is this module a grunt collection?
+      if (pkg.keywords.indexOf('gruntcollection') !== -1) {
+        msg = 'Detected grunt collection "' + basename + '".';
+        grunt.verbose.writeln(msg);
+        skip = false;
+      }
+      // Is this module a grunt plugin?
+      else if (pkg.keywords.indexOf('gruntplugin') !== -1) {
+        msg = 'Detected grunt plugin "' + basename + '".';
+        grunt.verbose.writeln(msg);
+        skip = false;
+      }
+    }
+    // If not, then skip.
+    if (skip) { return; }
+    // Otherwise, queue the module to be loaded.
+    modulesToLoad.push(basename);
+  });
+  // Return the modules to be loaded.
+  return modulesToLoad;
+};
+
+// Auto-load tasks and handlers from Npm modules detected to be Grunt plugins
+// or collections (installed relative to the base dir).
+task.autoloadNpmTasks = function(root) {
+  var msg = 'Auto-loading Npm tasks.';
+  grunt.verbose.subhead(msg);
+  // Detect the modules to be loaded.
+  var modulesToLoad;
+  modulesToLoad = task.detectNpmTasks(root);
+  // Load each of those modules.
+  modulesToLoad.forEach(function(name) {
+    task.loadNpmTasks(name);
+  });
 };
 
 // Load tasks and handlers from a given locally-installed Npm module (installed

--- a/test/grunt/task_test.js
+++ b/test/grunt/task_test.js
@@ -257,3 +257,29 @@ exports['task.normalizeMultiTaskFiles'] = {
     test.done();
   },
 };
+
+exports['task.autoLoadNpmTasks'] = {
+  setUp: function(done) {
+    this.cwd = process.cwd();
+    done();
+  },
+  tearDown: function(done) {
+    done();
+  },
+  'detect': function(test) {
+    test.expect(1);
+    var actual, expected;
+
+    // These are the plugins that the Grunt project use; maintain as necessary.
+    expected = [
+      'grunt-contrib-jshint',
+      'grunt-contrib-nodeunit',
+      'grunt-contrib-watch'
+    ].sort();
+
+    actual = grunt.task.detectNpmTasks().sort();
+    test.deepEqual(actual, expected, 'should detect all  grunt tasks in node_modules');
+
+    test.done();
+  }
+};


### PR DESCRIPTION
This commit adds a feature to auto-load all grunt plugins and collections that have been installed locally as Npm modules, to be used for convenience instead of a series of calls to `grunt.loadNpmTasks`. Use in a Gruntfile as follows:

``` js
  grunt.autoloadNpmTasks();
```

I added a test for the helper function `grunt.task.detectNpmTasks`. It appears there are no existing tests `grunt.task.npmLoadTasks` or `grunt.task.loadTasks`, so I didn't add any for `grunt.task.autoloadNpmTasks` directly either, but have tested the feature in local Grunt projects.

P.S. - Where do we update the documentation, as directed at [Contributing : Submitting pull requests #5](http://gruntjs.com/contributing#submitting-pull-requests)?
