### PR TITLE
Update task.js - a plugin can be a collection and a task at the same tim...

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -386,7 +386,6 @@ task.loadNpmTasks = function(name) {
       }
     });
     loadTaskDepth--;
-    return;
   }
 
   // Process task plugins.


### PR DESCRIPTION
...e

I am building a common build system for several frontend-projects and therefore am creating a super-task - a task composed of other tasks.

Using gruntcollection I can finally archieve it w/o the need to install those subtasks "locally". But a soon a I give it the keyword gruntcollection, I am not able to register Tasks directly in the composing-plugin
