### PR TITLE
Literate CoffeeScript support

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -32,6 +32,14 @@ var loadTaskDepth = 0;
 // Keep track of the number of log.error() calls.
 var errorcount;
 
+// Possible extensions of tasks files and Gruntfile itself.
+var extensions = [
+  'js',
+  'coffee',
+  'coffee.md',
+  'litcoffee'
+].join(',');
+
 // Override built-in registerTask.
 task.registerTask = function(name) {
   // Add task to registry.
@@ -342,7 +350,7 @@ function loadTasksMessage(info) {
 // Load tasks and handlers from a given directory.
 function loadTasks(tasksdir) {
   try {
-    var files = grunt.file.glob.sync('*.{js,coffee}', {cwd: tasksdir, maxDepth: 1});
+    var files = grunt.file.glob.sync('*.{' + extensions + '}', {cwd: tasksdir, maxDepth: 1});
     // Load tasks from files.
     files.forEach(function(filename) {
       loadTask(path.join(tasksdir, filename));
@@ -411,7 +419,7 @@ task.init = function(tasks, options) {
   // Get any local Gruntfile or tasks that might exist. Use --gruntfile override
   // if specified, otherwise search the current directory or any parent.
   var gruntfile = allInit ? null : grunt.option('gruntfile') ||
-    grunt.file.findup('Gruntfile.{js,coffee}', {nocase: true});
+    grunt.file.findup('Gruntfile.{' + extensions + '}', {nocase: true});
 
   var msg = 'Reading "' + (gruntfile ? path.basename(gruntfile) : '???') + '" Gruntfile...';
   if (gruntfile && grunt.file.exists(gruntfile)) {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "async": "~0.1.22",
-    "coffee-script": "~1.3.3",
+    "coffee-script": "~1.6.3",
     "colors": "~0.6.0-1",
     "dateformat": "1.0.2-1.2.3",
     "eventemitter2": "~0.4.9",


### PR DESCRIPTION
- 'coffee.md' and 'litcoffee' were added to files extensions list
  for tasks and Gruntfile.
- coffee-script was updated from version 1.3.3 to 1.6.3
  (Literate CS was introduced in version 1.5.0).

Closes gh-756, closes gh-767.
