### PR TITLE
Allow loadNpmTasks() to find tasks in parent directories.

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -366,8 +366,8 @@ task.loadTasks = function(tasksdir) {
 // relative to the base dir).
 task.loadNpmTasks = function(name) {
   loadTasksMessage('"' + name + '" local Npm module');
-  var root = path.resolve('node_modules');
-  var pkgfile = path.join(root, name, 'package.json');
+  var pkgfile = grunt.file.findup('node_modules/' + name + '/package.json');
+  var root = path.resolve(pkgfile, '../../');
   var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
 
   // Process collection plugins.


### PR DESCRIPTION
Changed to use grunt.file.findup to locate a package in a parent directory.  This is extremely valuable when using grunt on a wide variety of projects, mainly so npm install does not need to be run in each directory.
