### PR TITLE
automatically load tasks from package.json

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -412,13 +412,15 @@ task.init = function(tasks, options) {
   // if specified, otherwise search the current directory or any parent.
   var gruntfile = allInit ? null : grunt.option('gruntfile') ||
     grunt.file.findup('Gruntfile.{js,coffee}', {nocase: true});
+  var workingDirectory = null;
 
   var msg = 'Reading "' + (gruntfile ? path.basename(gruntfile) : '???') + '" Gruntfile...';
   if (gruntfile && grunt.file.exists(gruntfile)) {
     grunt.verbose.writeln().write(msg).ok();
     // Change working directory so that all paths are relative to the
     // Gruntfile's location (or the --base option, if specified).
-    process.chdir(grunt.option('base') || path.dirname(gruntfile));
+    workingDirectory = grunt.option('base') || path.dirname(gruntfile);
+    process.chdir(workingDirectory);
     // Load local tasks, if the file exists.
     loadTasksMessage('Gruntfile');
     loadTask(gruntfile);
@@ -440,6 +442,11 @@ task.init = function(tasks, options) {
 
   // Load all user-specified --npm tasks.
   (grunt.option('npm') || []).forEach(task.loadNpmTasks);
+  // Load all grunt-* dependency tasks declared in the package.json
+  if (workingDirectory && grunt.file.exists(workingDirectory + '/package.json')) {
+    var packageFile = require(workingDirectory + '/package.json');
+    require('matchdep').filterAll('grunt-*', packageFile).forEach(grunt.loadNpmTasks);
+  }
   // Load all user-specified --tasks.
   (grunt.option('tasks') || []).forEach(task.loadTasks);
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "lodash": "~0.9.0",
     "underscore.string": "~2.2.0rc",
     "which": "~1.0.5",
-    "js-yaml": "~2.0.2"
+    "js-yaml": "~2.0.2",
+    "matchdep": "~0.1.2"
   },
   "devDependencies": {
     "temporary": "~0.0.4",


### PR DESCRIPTION
Removes the need to to do `grunt.loadNpmTasks('myNpmTasks')` for every npm-loaded task in your package.json.
