### PR TITLE
fix underscore.string version 2.2.0rc to 2.2.0-rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nopt": "~1.0.10",
     "rimraf": "~2.0.2",
     "lodash": "~0.9.0",
-    "underscore.string": "~2.2.0rc",
+    "underscore.string": "~2.2.0-rc",
     "which": "~1.0.5",
     "js-yaml": "~2.0.2"
   },


### PR DESCRIPTION
Hi, I can't install gruntjs.

```
$ npm install grunt
```

then error

```
npm ERR! Error: No compatible version found: underscore.string@'>=2.2.0rc <2.3.0-'
npm ERR! Valid install targets:
npm ERR! ["0.9.2","1.0.0","1.1.3","1.1.4","1.1.5","1.1.6","2.0.0","2.1.0","2.1.1","2.3.0","2.3.1","2.2.0-rc"]
```

so I fixed `package.json` dependencies version.

thanks.
