### PR TITLE
remove rc version requirement from underscore.string

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nopt": "~1.0.10",
     "rimraf": "~2.0.2",
     "lodash": "~0.9.0",
-    "underscore.string": "~2.2.0rc",
+    "underscore.string": "~2.2.0",
     "which": "~1.0.5",
     "js-yaml": "~2.0.2"
   },


### PR DESCRIPTION
undescore.string rc version seem to no longer exists which causes an exception
