### PR TITLE
Increase speed of finding matched files when exclude is overly broad

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -46,23 +46,29 @@ file.setBase = function() {
 
 // Process specified wildcard glob patterns or filenames against a
 // callback, excluding and uniquing files in the result set.
-var processPatterns = function(patterns, fn) {
+var processPatterns = function(patterns, options, fn) {
   // Filepaths to return.
-  var result = [];
+  var result = [],
+     _ = grunt.util._;
+
   // Iterate over flattened patterns array.
-  grunt.util._.flatten(patterns).forEach(function(pattern) {
+  _.flatten(patterns).forEach(function(pattern) {
     // If the first character is ! it should be omitted
     var exclusion = pattern.indexOf('!') === 0;
-    // If the pattern is an exclusion, remove the !
-    if (exclusion) { pattern = pattern.slice(1); }
-    // Find all matching files for this pattern.
-    var matches = fn(pattern);
     if (exclusion) {
-      // If an exclusion, remove matching files.
-      result = grunt.util._.difference(result, matches);
-    } else {
-      // Otherwise add matching files.
-      result = grunt.util._.union(result, matches);
+      // Strip the ! so that the matching works
+      pattern = pattern.slice(1);
+
+      // Remove any files from the current set that match the exclude pattern
+      var filter_func = file.minimatch.filter(pattern, options);
+      result = _.filter(result, function(fpath) {
+        return ! filter_func(fpath);
+      });
+    }
+    else {
+      // Find all matching files for this pattern.
+      // And extend the result set
+      result = _.union(result, fn(pattern));
     }
   });
   return result;
@@ -84,7 +90,7 @@ file.match = function(options, patterns, filepaths) {
   // Return empty set if there are no patterns or filepaths.
   if (patterns.length === 0 || filepaths.length === 0) { return []; }
   // Return all matching filepaths.
-  return processPatterns(patterns, function(pattern) {
+  return processPatterns(patterns, options, function(pattern) {
     return file.minimatch.match(filepaths, pattern, options);
   });
 };
@@ -107,7 +113,7 @@ file.expand = function() {
   // Return empty set if there are no patterns or filepaths.
   if (patterns.length === 0) { return []; }
   // Return all matching filepaths.
-  var matches = processPatterns(patterns, function(pattern) {
+  var matches = processPatterns(patterns, options, function(pattern) {
     // Find all matching files for this pattern.
     return file.glob.sync(pattern, options);
   });


### PR DESCRIPTION
Long ago it seems our grunt file had patterns like below to find all of the source javascript files but exclude our specs.  

``` javascript
['app/**/*.js', '!**/*_spec.js'] // Note missing app at the front of the exclude to scope the glob.
```

This worked fine until we upgraded to grunt 0.4.  Then our builds got much slower, 0.5 seconds to 10 seconds.  The culprit was the negation of the specs. Grunt currently is running the negation glob against the file system and then removing the excluded files.  This is fine for small systems (or well written excludes) but is slow when you have lots of files (or poorly written globs).  At any rate there is no reason to hit the disk just to exclude file paths which are already known.
- [x] Test suite passes
- [x] Add a test (I did not do this since I could not determine a way to asset that we did not touch disk for the negate step).
