### PR TITLE
LoadNpmTasks from parent node_modules

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -366,8 +366,8 @@ task.loadTasks = function(tasksdir) {
 // relative to the base dir).
 task.loadNpmTasks = function(name) {
   loadTasksMessage('"' + name + '" local Npm module');
-  var root = path.resolve('node_modules');
-  var pkgfile = path.join(root, name, 'package.json');
+  var pkgfile = grunt.file.findup(path.join('node_modules', name, 'package.json'));
+  var root = path.dirname(pkgfile);
   var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
 
   // Process collection plugins.
@@ -377,7 +377,7 @@ task.loadNpmTasks = function(name) {
       // Npm sometimes pulls dependencies out if they're shared, so find
       // upwards if not found locally.
       var filepath = grunt.file.findup('node_modules/' + depName, {
-        cwd: path.resolve('node_modules', name),
+        cwd: root,
         nocase: true
       });
       if (filepath) {
@@ -390,7 +390,7 @@ task.loadNpmTasks = function(name) {
   }
 
   // Process task plugins.
-  var tasksdir = path.join(root, name, 'tasks');
+  var tasksdir = path.join(root, 'tasks');
   if (grunt.file.exists(tasksdir)) {
     loadTasks(tasksdir);
   } else {


### PR DESCRIPTION
Allow `npm` tasks to be loaded from parents `node_modules` folders if the local one was not found.
Thanks @even !
