### PR TITLE
Load NPM tasks using require

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -294,16 +294,43 @@ task.runAllTargets = function(taskname, args) {
   });
 };
 
-// Load tasks and handlers from a given tasks file.
+// Log tasks that where (un)loaded
+// 3 functions, one to call before load (prepare)
+// the 2nd one is to do the actual log
+// the 3rd is for cleanup (clean)
 var loadTaskStack = [];
-function loadTask(filepath) {
+function prepareLoadTaskLog(filepath) {
   // In case this was called recursively, save registry for later.
   loadTaskStack.push(registry);
   // Reset registry.
   registry = {tasks: [], untasks: [], meta: {info: lastInfo, filepath: filepath}};
+}
+function loadTaskLog(msg) {
+  var regCount = 0;
+
+  grunt.verbose.write(msg).ok();
+  // Log registered/renamed/unregistered tasks.
+  ['un', ''].forEach(function(prefix) {
+    var list = grunt.util._.chain(registry[prefix + 'tasks']).uniq().sort().value();
+    if (list.length > 0) {
+      regCount++;
+      grunt.verbose.writeln((prefix ? '- ' : '+ ') + grunt.log.wordlist(list));
+    }
+  });
+  if (regCount === 0) {
+    grunt.verbose.error('No tasks were registered or unregistered.');
+  }
+}
+function cleanLoadTaskLog() {
+  // Restore registry.
+  registry = loadTaskStack.pop() || {};
+}
+
+// Load tasks and handlers from a given tasks file.
+function loadTask(filepath) {
+  prepareLoadTaskLog(filepath);
   var filename = path.basename(filepath);
   var msg = 'Loading "' + filename + '" tasks...';
-  var regCount = 0;
   var fn;
   try {
     // Load taskfile.
@@ -311,24 +338,12 @@ function loadTask(filepath) {
     if (typeof fn === 'function') {
       fn.call(grunt, grunt);
     }
-    grunt.verbose.write(msg).ok();
-    // Log registered/renamed/unregistered tasks.
-    ['un', ''].forEach(function(prefix) {
-      var list = grunt.util._.chain(registry[prefix + 'tasks']).uniq().sort().value();
-      if (list.length > 0) {
-        regCount++;
-        grunt.verbose.writeln((prefix ? '- ' : '+ ') + grunt.log.wordlist(list));
-      }
-    });
-    if (regCount === 0) {
-      grunt.verbose.error('No tasks were registered or unregistered.');
-    }
+    loadTaskLog(msg);
   } catch(e) {
     // Something went wrong.
     grunt.log.write(msg).error().verbose.error(e.stack).or.error(e);
   }
-  // Restore registry.
-  registry = loadTaskStack.pop() || {};
+  cleanLoadTaskLog();
 }
 
 // Log a message when loading tasks.
@@ -362,10 +377,10 @@ task.loadTasks = function(tasksdir) {
   }
 };
 
+// DEPRECATED - Old method to load NPM tasks
 // Load tasks and handlers from a given locally-installed Npm module (installed
 // relative to the base dir).
-task.loadNpmTasks = function(name) {
-  loadTasksMessage('"' + name + '" local Npm module');
+function deprecatedLoadNpmTasks(name) {
   var root = path.resolve('node_modules');
   var pkgfile = path.join(root, name, 'package.json');
   var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
@@ -382,7 +397,7 @@ task.loadNpmTasks = function(name) {
       });
       if (filepath) {
         // Load this task plugin recursively.
-        task.loadNpmTasks(path.relative(root, filepath));
+        deprecatedLoadNpmTasks(path.relative(root, filepath));
       }
     });
     loadTaskDepth--;
@@ -392,9 +407,44 @@ task.loadNpmTasks = function(name) {
   // Process task plugins.
   var tasksdir = path.join(root, name, 'tasks');
   if (grunt.file.exists(tasksdir)) {
+    grunt.log.error('Warning - Local Npm module "' + name + '" is using a deprecated load mechanism. Please update this package.');
     loadTasks(tasksdir);
   } else {
     grunt.log.error('Local Npm module "' + name + '" not found. Is it installed?');
+  }
+}
+
+// Load tasks and handlers from a given Npm module using standard require
+task.loadNpmTasks = function(name) {
+  loadTasksMessage('"' + name + '" Npm package');
+  
+  var fn;
+  try {
+    // Load the module with require
+    var module = require(name);
+    // Look for the standard registerNpmTasks function
+    if ('registerNpmTasks' in module) {
+      fn = module.registerNpmTasks;
+    }
+  }
+  catch(e) {}
+
+  // If we found a valid function, execute it properly
+  if (grunt.util._.isFunction(fn)) {
+    prepareLoadTaskLog();
+    try {
+      var msg = 'Loading Npm package "' + name + '" tasks...';
+      fn.call(grunt, grunt);
+      loadTaskLog(msg);
+    } catch(e) {
+      // Something went wrong.
+      grunt.log.write(msg).error().verbose.error(e.stack).or.error(e);
+    }
+    cleanLoadTaskLog();
+  }
+  // Otherwise, use the deprecated loading method
+  else {
+    deprecatedLoadNpmTasks(name);
   }
 };
 


### PR DESCRIPTION
The basic idea behind this patch is to allow the full use of Npm as expected from the user. Loading Npm tasks should permit to load tasks from parent node_module folders.

The problem was that modules were not designed at all to permit this. Thus, modifying the load mechanism would break every one of them. This is baaad.

I worked out a way to use a brand new loading mechanism based on a require approach but to still retain the old approach during some time to allow packages to migrate to the new way.

To make a module compliant with the new load, you can just add in your main package script something like that:

``` js
module.exports.registerNpmTasks = function(grunt) {
  grunt.loadTasks(__dirname + '/tasks');
}
```

and that's all the work required.

When a package does not export this function, the old loading mechanism is tried. If it succeeds, a warning is issued to let people know this package requires an update.

To prevent code duplication I had to move away code and create some more functions. If you don't like anything in this patch, I would be happy to make any changes you deem required.
