### PR TITLE
fixbug for get part of filename when filename contains two '.'

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -151,7 +151,7 @@ file.expandMapping = function(patterns, destBase, options) {
     }
     // Change the extension?
     if (options.ext) {
-      destPath = destPath.replace(/(\.[^\/]*)?$/, options.ext);
+      destPath = destPath.replace(/(\.[^\/\.]*)?$/, options.ext);
     }
     // Generate destination filename.
     var dest = options.rename(destBase, destPath, options);


### PR DESCRIPTION
when use [Building the files object dynamically](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically)
like this:

``` js
{
    expand: true,
    src: [PATH_SRC + APP_NAME + '/*.js', PATH_SRC + APP_NAME + '/**/*.js'],
    dest: PATH_DEST,
    ext: '.js',
    rename: function(dest, src) { console.log(src);
        var version = getVersion(src, PATH_TMP + APP_NAME + '.json', grunt);
        return version && (dest + version);
    }
}
```

If there has a js file like zepto.min.js, and the output is zepto.js.
