### PR TITLE
Added npm version and dependency status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Grunt: The JavaScript Task Runner [![Build Status](https://secure.travis-ci.org/gruntjs/grunt.png?branch=master)](http://travis-ci.org/gruntjs/grunt)
+# Grunt: The JavaScript Task Runner [![Build Status](https://secure.travis-ci.org/gruntjs/grunt.png?branch=master)](http://travis-ci.org/gruntjs/grunt) [![NPM version](https://badge.fury.io/js/grunt.png)](http://badge.fury.io/js/grunt) [![Dependency Status](https://gemnasium.com/gruntjs/grunt.png)](https://gemnasium.com/gruntjs/grunt)
 
 <img align="right" height="260" src="http://gruntjs.com/img/grunt-logo-no-wordmark.svg">
 


### PR DESCRIPTION
It would be nice to keep track of the latest npm version and dependencies via badges in the README. The version is simply a nice convenience for users to check if they have the latest, and the dependency status badge will help grunt stay up to date with new dependency versions so that it doesn't get too far behind and then struggle to update.
