### PR TITLE
fixed extension issue (issue #862 )

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -151,7 +151,8 @@ file.expandMapping = function(patterns, destBase, options) {
     }
     // Change the extension?
     if (options.ext) {
-      destPath = destPath.replace(/(\.[^\/]*)?$/, options.ext);
+        destPath = destPath.substr(0, destPath.lastIndexOf('.')) || destPath;
+    	destPath += options.ext; 
     }
     // Generate destination filename.
     var dest = options.rename(destBase, destPath, options);


### PR DESCRIPTION
On file with multiple dots, extension is broken
Eg: on {ext:'.js'} myscript.prod.dust => myscript.js, instead it should
produce mysqcript.prod.js
