### PR TITLE
Removed --stack option to always print stack traces for errors

### DIFF
--- a/lib/grunt/cli.js
+++ b/lib/grunt/cli.js
@@ -63,10 +63,6 @@ var optlist = cli.optlist = {
     info: 'Enable debugging mode for tasks that support it.',
     type: Number
   },
-  stack: {
-    info: 'Print a stack trace when exiting with a warning or fatal error.',
-    type: Boolean
-  },
   force: {
     short: 'f',
     info: 'A way to force your way past warnings. Want a suggestion? Don\'t use this option, fix your code.',

--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -39,14 +39,11 @@ function writeln(e, mode) {
   grunt.log.writeln(msg);
 }
 
-// If --stack is enabled, log the appropriate error stack (if it exists).
 function dumpStack(e) {
-  if (grunt.option('stack')) {
-    if (e.origError && e.origError.stack) {
-      console.log(e.origError.stack);
-    } else if (e.stack) {
-      console.log(e.stack);
-    }
+  if (e.origError && e.origError.stack) {
+    console.log(e.origError.stack);
+  } else if (e.stack) {
+    console.log(e.stack);
   }
 }
 


### PR DESCRIPTION
I have seen so much frustration from grunt users not knowing about --stack. I don't see why you _wouldn't_ want to see a stack trace when an error occurs.
