### PR TITLE
Remove warning from test suite run

### DIFF
--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -571,7 +571,10 @@ exports['file'] = {
   },
   'delete nonexistent file': function(test) {
     test.expect(1);
+    var oldWarn = grunt.log.warn;
+    grunt.log.warn = function() {};
     test.ok(!grunt.file.delete('nonexistent'), 'should return false if file does not exist.');
+    grunt.log.warn = oldWarn;
     test.done();
   },
   'delete outside working directory': function(test) {


### PR DESCRIPTION
Deleting a non-existent file throws a warning. The warning is scary and unneeded when running the tests. Suppressed the display of the warning similar to other tests
