### PR TITLE
Add support for specifying `process.execArgv` for grunt.util.spawn()

### DIFF
--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -168,7 +168,7 @@ util.spawn = function(opts, done) {
     args = opts.args;
   }
 
-  var execArgv = opts.execArgv ? opts.execArgv : process.execArgv;
+  var execArgv = opts.execArgv || process.execArgv;
   args = execArgv.concat(args);
 
   var child = spawn(cmd, args, opts.opts);

--- a/test/fixtures/spawn-execArgv.js
+++ b/test/fixtures/spawn-execArgv.js
@@ -1,10 +1,11 @@
 
 const FIXTURE = 'constant';
 
+// when --harmony was specified, a `const` cannot be changed
 FIXTURE = 'variable';
 
 process.stdout.write(FIXTURE + '\n' + process.execArgv.indexOf('--harmony'));
 
 // Use instead of process.exit to ensure stdout/stderr are flushed
 // before exiting in Windows (Tested in Node.js v0.8.7)
-require('../../lib/util/exit').exit(0);
+require('exit')(0);

--- a/test/grunt/util_test.js
+++ b/test/grunt/util_test.js
@@ -271,15 +271,22 @@ exports['util.spawn'] = {
   },
 };
 
+var harmonyWasSetAtIndex = -1;
 exports['util.spawn.execArgv'] = {
   setUp: function(done) {
     // clear '--harmony' flag for testing
-    var harmonyIndex = process.execArgv.indexOf('--harmony');
-    if (harmonyIndex !== -1) {
-      process.execArgv.splice(harmonyIndex, 1);
+    harmonyWasSetAtIndex = process.execArgv.indexOf('--harmony');
+    if (harmonyWasSetAtIndex !== -1) {
+      process.execArgv.splice(harmonyWasSetAtIndex, 1);
     }
 
     this.script = path.resolve('test/fixtures/spawn-execArgv.js');
+    done();
+  },
+  tearDown: function(done) {
+    if (harmonyWasSetAtIndex !== -1) {
+      process.execArgv.splice(harmonyWasSetAtIndex, 0, '--harmony');
+    }
     done();
   },
   'inherit execArgv': function(test) {
@@ -296,6 +303,8 @@ exports['util.spawn.execArgv'] = {
       var outputs = result.stdout.split('\n');
       test.equals(outputs[0], 'constant');
       test.equals(outputs[1], '0');
+      // clear mock '--harmony'
+      process.execArgv.shift('--harmony');
       test.done();
     });
   },


### PR DESCRIPTION
Consider the harmony use case, say, the grunt command is invoked with `--harmony` flag, like this:

```
node --harmony --harmony_typeof ./node_modules/.bin/grunt
```

In node v0.11, it seems `process.execArgv` is no longer included as part of `process.argv`
