### PR TITLE
Replace colors.js by chalk

### DIFF
--- a/lib/grunt/log.js
+++ b/lib/grunt/log.js
@@ -18,19 +18,19 @@ var util = require('util');
 var log = module.exports = {};
 
 // External lib. Requiring this here modifies the String prototype!
-var colors = require('colors');
+var chalk = require('chalk');
 
 // Disable colors if --no-colors was passed.
 log.initColors = function() {
   var util = grunt.util;
   if (grunt.option('no-color')) {
     // String color getters should just return the string.
-    colors.mode = 'none';
+    chalk.enabled = false;
     // Strip colors from strings passed to console.log.
     util.hooker.hook(console, 'log', function() {
       var args = util.toArray(arguments);
       return util.hooker.filter(this, args.map(function(arg) {
-        return util.kindOf(arg) === 'string' ? colors.stripColors(arg) : arg;
+        return util.kindOf(arg) === 'string' ? chalk.stripColor(arg) : arg;
       }));
     });
   }
@@ -49,9 +49,9 @@ var hasLogged;
 function markup(str) {
   str = str || '';
   // Make _foo_ underline.
-  str = str.replace(/(\s|^)_(\S|\S[\s\S]+?\S)_(?=[\s,.!?]|$)/g, '$1' + '$2'.underline);
+  str = str.replace(/(\s|^)_(\S|\S[\s\S]+?\S)_(?=[\s,.!?]|$)/g, '$1' + chalk.underline('$2'));
   // Make *foo* bold.
-  str = str.replace(/(\s|^)\*(\S|\S[\s\S]+?\S)\*(?=[\s,.!?]|$)/g, '$1' + '$2'.bold);
+  str = str.replace(/(\s|^)\*(\S|\S[\s\S]+?\S)\*(?=[\s,.!?]|$)/g, '$1' + chalk.bold('$2'));
   return str;
 }
 
@@ -73,7 +73,7 @@ function write(msg) {
     hasLogged = true;
     // Users should probably use the colors-provided methods, but if they
     // don't, this should strip extraneous color codes.
-    if (grunt.option('no-color')) { msg = colors.stripColors(msg); }
+    if (grunt.option('no-color')) { msg = chalk.stripColor(msg); }
     // Actually write to stdout.
     process.stdout.write(markup(msg));
   }
@@ -100,9 +100,9 @@ log.writeln = function() {
 log.warn = function() {
   var msg = format(arguments);
   if (arguments.length > 0) {
-    writeln('>> '.red + grunt.util._.trim(msg).replace(/\n/g, '\n>> '.red));
+    writeln(chalk.red('>> ') + grunt.util._.trim(msg).replace(/\n/g, chalk.red('\n>> ')));
   } else {
-    writeln('ERROR'.red);
+    writeln(chalk.red('ERROR'));
   }
   return log;
 };
@@ -114,9 +114,9 @@ log.error = function() {
 log.ok = function() {
   var msg = format(arguments);
   if (arguments.length > 0) {
-    writeln('>> '.green + grunt.util._.trim(msg).replace(/\n/g, '\n>> '.green));
+    writeln(chalk.green('>> ') + grunt.util._.trim(msg).replace(/\n/g, chalk.green('\n>> ')));
   } else {
-    writeln('OK'.green);
+    writeln(chalk.green('OK'));
   }
   return log;
 };
@@ -132,33 +132,33 @@ log.oklns = function() {
 };
 log.success = function() {
   var msg = format(arguments);
-  writeln(msg.green);
+  writeln(chalk.green(msg));
   return log;
 };
 log.fail = function() {
   var msg = format(arguments);
-  writeln(msg.red);
+  writeln(chalk.red(msg));
   return log;
 };
 log.header = function() {
   var msg = format(arguments);
   // Skip line before header, but not if header is the very first line output.
   if (hasLogged) { writeln(); }
-  writeln(msg.underline);
+  writeln(chalk.underline(msg));
   return log;
 };
 log.subhead = function() {
   var msg = format(arguments);
   // Skip line before subhead, but not if subhead is the very first line output.
   if (hasLogged) { writeln(); }
-  writeln(msg.bold);
+  writeln(chalk.bold(msg));
   return log;
 };
 // For debugging.
 log.debug = function() {
   var msg = format(arguments);
   if (grunt.option('debug')) {
-    writeln('[D] ' + msg.magenta);
+    writeln('[D] ' + chalk.magenta(msg));
   }
   return log;
 };
@@ -187,7 +187,7 @@ log.writeflags = function(obj, prefix) {
       return key + (val === true ? '' : '=' + JSON.stringify(val));
     }));
   }
-  writeln((prefix || 'Flags') + ': ' + (wordlist || '(none)'.cyan));
+  writeln((prefix || 'Flags') + ': ' + (wordlist || chalk.cyan('(none)')));
   return log;
 };
 
@@ -234,7 +234,7 @@ log.wordlist = function(arr, options) {
     color: 'cyan'
   });
   return arr.map(function(item) {
-    return options.color ? String(item)[options.color] : item;
+    return options.color ? chalk[options.color](String(item)) : item;
   }).join(options.separator);
 };
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "async": "~0.1.22",
     "coffee-script": "~1.3.3",
-    "colors": "~0.6.0-1",
     "dateformat": "1.0.2-1.2.3",
     "eventemitter2": "~0.4.9",
     "findup-sync": "~0.1.0",
@@ -59,7 +58,8 @@
     "lodash": "~0.9.0",
     "underscore.string": "~2.2.0rc",
     "which": "~1.0.5",
-    "js-yaml": "~2.0.2"
+    "js-yaml": "~2.0.2",
+    "chalk": "~0.2.0"
   },
   "devDependencies": {
     "temporary": "~0.0.4",


### PR DESCRIPTION
As discussed in #879

It should be noted that removing color.js also remove the global `String.prototype` extension, so every grunt-plugin not listing their own version of colors.js as dependency will have trouble as they relied on a global prototype extension and not on their module own ecosystem. That seems to be the case of many grunt-contrib plugins.
