### PR TITLE
Fix underscore.string dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nopt": "~1.0.10",
     "rimraf": "~2.0.2",
     "lodash": "~0.9.0",
-    "underscore.string": "~2.2.0rc",
+    "underscore.string": "~2.2.0-rc",
     "which": "~1.0.5",
     "js-yaml": "~2.0.2"
   },


### PR DESCRIPTION
According to the [npm registry](http://registry.npmjs.org/underscore.string), there is no `underscore.string@2.2.0rc`, instead the version is `2.2.0-rc`.
