### PR TITLE
Support .litcoffee and coffee.md extensions

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -411,7 +411,7 @@ task.init = function(tasks, options) {
   // Get any local Gruntfile or tasks that might exist. Use --gruntfile override
   // if specified, otherwise search the current directory or any parent.
   var gruntfile = allInit ? null : grunt.option('gruntfile') ||
-    grunt.file.findup('Gruntfile.{js,coffee,coffee.md}', {nocase: true});
+    grunt.file.findup('Gruntfile.{js,coffee,litcoffee,coffee.md}', {nocase: true});
 
   var msg = 'Reading "' + (gruntfile ? path.basename(gruntfile) : '???') + '" Gruntfile...';
   if (gruntfile && grunt.file.exists(gruntfile)) {

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -411,7 +411,7 @@ task.init = function(tasks, options) {
   // Get any local Gruntfile or tasks that might exist. Use --gruntfile override
   // if specified, otherwise search the current directory or any parent.
   var gruntfile = allInit ? null : grunt.option('gruntfile') ||
-    grunt.file.findup('Gruntfile.{js,coffee}', {nocase: true});
+    grunt.file.findup('Gruntfile.{js,coffee,coffee.md}', {nocase: true});
 
   var msg = 'Reading "' + (gruntfile ? path.basename(gruntfile) : '???') + '" Gruntfile...';
   if (gruntfile && grunt.file.exists(gruntfile)) {


### PR DESCRIPTION
At GitHub, we have a few people that're :heart_eyes: for [literate Coffeescript](http://ashkenas.com/literate-coffeescript/). I thought it might be nice to have Gruntfiles support those extensions as well.
