### PR TITLE
orders of magnitude speed increase in processPatterns for large excludes

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -46,23 +46,19 @@ file.setBase = function() {
 
 // Process specified wildcard glob patterns or filenames against a
 // callback, excluding and uniquing files in the result set.
-var processPatterns = function(patterns, fn) {
+var processPatterns = function(patterns, fn, options) {
   // Filepaths to return.
   var result = [];
   // Iterate over flattened patterns array.
   grunt.util._.flatten(patterns).forEach(function(pattern) {
     // If the first character is ! it should be omitted
-    var exclusion = pattern.indexOf('!') === 0;
     // If the pattern is an exclusion, remove the !
-    if (exclusion) { pattern = pattern.slice(1); }
-    // Find all matching files for this pattern.
-    var matches = fn(pattern);
-    if (exclusion) {
-      // If an exclusion, remove matching files.
-      result = grunt.util._.difference(result, matches);
+    if (pattern.indexOf('!') === 0) {
+      result = file.minimatch.match(result, pattern, options || {});
     } else {
+      // Find all matching files for this pattern.
       // Otherwise add matching files.
-      result = grunt.util._.union(result, matches);
+      result = grunt.util._.union(result, fn(pattern));
     }
   });
   return result;
@@ -86,7 +82,7 @@ file.match = function(options, patterns, filepaths) {
   // Return all matching filepaths.
   return processPatterns(patterns, function(pattern) {
     return file.minimatch.match(filepaths, pattern, options);
-  });
+  }, options);
 };
 
 // Match a filepath or filepaths against one or more wildcard patterns. Returns
@@ -110,7 +106,7 @@ file.expand = function() {
   var matches = processPatterns(patterns, function(pattern) {
     // Find all matching files for this pattern.
     return file.glob.sync(pattern, options);
-  });
+  }, options);
   // Filter result set?
   if (options.filter) {
     matches = matches.filter(function(filepath) {


### PR DESCRIPTION
There is no reason to actually call out to the file system for excluded patterns.  They can be filtered out by pattern matching alone.
