### PR TITLE
regexp error with '*.*.*.extname'

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -151,7 +151,7 @@ file.expandMapping = function(patterns, destBase, options) {
     }
     // Change the extension?
     if (options.ext) {
-      destPath = destPath.replace(/(\.[^\/]*)?$/, options.ext);
+      destPath = destPath.replace(/\.([^\/\.]*)?$/, options.ext);
     }
     // Generate destination filename.
     var dest = options.rename(destBase, destPath, options);


### PR DESCRIPTION
Regexp errors with e.g. 'jquery.ui.somemodule.coffee' to 'jquery.ui.somemodule.js'
It should exclude '.' also.
