### PR TITLE
Update for boolean option flags passed to CLI. Fixes #920

### DIFF
--- a/lib/grunt/cli.js
+++ b/lib/grunt/cli.js
@@ -115,6 +115,15 @@ Object.keys(optlist).forEach(function(key) {
   known[key] = optlist[key].type;
 });
 
+Object.keys( process.argv ).forEach( function ( key ) {
+  var isFlag = /\-\-\w+/.test( process.argv[ key ] ),
+      isAssigned = /\-\-\w+=/.test( process.argv[ key ] );
+
+  if ( isFlag && !isAssigned ) {
+    process.argv[key] = process.argv[key] + "=true";
+  }
+});
+
 var parsed = nopt(known, aliases, process.argv, 2);
 cli.tasks = parsed.argv.remain;
 cli.options = parsed;


### PR DESCRIPTION
When boolean options are passed along with secondary flags, those secondary flags become the value for the boolean (shown in the issue report on #920).

This is caused by how the arguments are passed to `nopt` to pull those pieces together.  This update simply iterates against the arguments in the process list (`process.argv`) and for those that are a flag without a value (e.g. `--build`) it will assign append an `=true` to the value.

Not sure this is the most elegant fix, but it is simple and does cause flags to be parsed appropriately.
