### PR TITLE
Hide tasks with 'undefined' description in '--help'

### DIFF
--- a/lib/grunt/help.js
+++ b/lib/grunt/help.js
@@ -103,7 +103,9 @@ exports.tasks = function() {
   if (exports._tasks.length === 0) {
     grunt.log.writeln('(no tasks found)');
   } else {
-    exports.table(exports._tasks.map(function(task) {
+    exports.table(exports._tasks.filter(function(task) {
+        return task.list;
+    }).map(function(task) {
       var info = task.info;
       if (task.multi) { info += ' *'; }
       return [task.name, info];

--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -58,6 +58,9 @@
       fn = info;
       info = null;
     }
+    // list the task in the help
+    var list = (info !== undefined);
+
     // String or array of strings was passed instead of fn.
     var tasks;
     if (typeof fn !== 'function') {
@@ -75,7 +78,7 @@
       info = 'Custom task.';
     }
     // Add task into cache.
-    this._tasks[name] = {name: name, info: info, fn: fn};
+    this._tasks[name] = {name: name, info: info, list: list, fn: fn};
     // Make chainable!
     return this;
   };


### PR DESCRIPTION
The following task would not appear in the `grunt --help` output:

```
grunt.registerTask("minify", undefined, [
       "cssmin",
       "compress:js"
]);
```

whereas it would normally if the 'undefined' is omitted (including the Alias listing).
