### PR TITLE
Enabling case insensitive file handling by default

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -100,7 +100,7 @@ file.expand = function() {
   var args = grunt.util.toArray(arguments);
   // If the first argument is an options object, save those options to pass
   // into the file.glob.sync method.
-  var options = grunt.util.kindOf(args[0]) === 'object' ? args.shift() : {};
+  var options = grunt.util.kindOf(args[0]) === 'object' ? args.shift() : win32 ? { nocase: true } : { };
   // Use the first argument if it's an Array, otherwise convert the arguments
   // object to an array and use that.
   var patterns = Array.isArray(args[0]) ? args[0] : args;


### PR DESCRIPTION
Plug-ins that don't fully embrace the dynamic file expansion don't provide any nice way of telling their patterns to ignore case when on Windows. This will ensure the default options for those plugins (i.e. eslint-grunt) will automagically use case insensitive search.

I know the extra ?: operator makes this line a bit of a kludge, but wanted to submit the issue with an example of the workaround.  Happy to refine further if you wish.
