### PR TITLE
Enabling case insensitive file handling by default

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -101,6 +101,10 @@ file.expand = function() {
   // If the first argument is an options object, save those options to pass
   // into the file.glob.sync method.
   var options = grunt.util.kindOf(args[0]) === 'object' ? args.shift() : {};
+  // Use a case insensitive search if running on Windows.
+  if(win32) {
+    options.nocase = true;
+  }
   // Use the first argument if it's an Array, otherwise convert the arguments
   // object to an array and use that.
   var patterns = Array.isArray(args[0]) ? args[0] : args;


### PR DESCRIPTION
Plug-ins that don't fully embrace the dynamic file expansion don't provide a nice way of use patterns that are case insensitive when on Windows. This will ensure the default options for those plugins that don't allow for full use of the dynamic expansion (i.e. eslint-grunt) will automagically use case insensitive search on Windows.
