### PR TITLE
Added ability to not run a specific task by passing --no-<taskname> on CLI

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -45,8 +45,10 @@ task.registerTask = function(name) {
   // Override task function.
   var _fn = thisTask.fn;
   thisTask.fn = function(arg) {
-    // Guaranteed to always be the actual task name.
-    var name = thisTask.name;
+    if (grunt.option(name) === false) {
+      grunt.verbose.write('Task run deactivated.').ok();
+      return;
+    }
     // Initialize the errorcount for this task.
     errorcount = grunt.fail.errorcount;
     // Return the number of errors logged during this task.
@@ -60,15 +62,13 @@ task.registerTask = function(name) {
     this.requires = task.requires.bind(task);
     // Expose config.requires on `this`.
     this.requiresConfig = grunt.config.requires;
-    // Return an options object with the specified defaults overwritten by task-
+    // Return an options object with the specified defaults overriden by task-
     // specific overrides, via the "options" property.
     this.options = function() {
       var args = [{}].concat(grunt.util.toArray(arguments)).concat([
         grunt.config([name, 'options'])
       ]);
-      var options = grunt.util._.extend.apply(null, args);
-      grunt.verbose.writeflags(options, 'Options');
-      return options;
+      return grunt.util._.extend.apply(null, args);
     };
     // If this task was an alias or a multi task called without a target,
     // only log if in verbose mode.
@@ -226,13 +226,16 @@ task.registerMultiTask = function(name, info, fn) {
     this.args = grunt.util.toArray(arguments).slice(1);
     // If a target wasn't specified, run this task once for each target.
     if (!target || target === '*') {
+      if (grunt.option(name) === false) {
+        return;
+      }
       return task.runAllTargets(name, this.args);
     } else if (!isValidMultiTaskTarget(target)) {
       throw new Error('Invalid target "' + target + '" specified.');
     }
     // Fail if any required config properties have been omitted.
     this.requiresConfig([name, target]);
-    // Return an options object with the specified defaults overwritten by task-
+    // Return an options object with the specified defaults overriden by task-
     // and/or target-specific overrides, via the "options" property.
     this.options = function() {
       var targetObj = grunt.config([name, target]);
@@ -240,9 +243,7 @@ task.registerMultiTask = function(name, info, fn) {
         grunt.config([name, 'options']),
         grunt.util.kindOf(targetObj) === 'object' ? targetObj.options : {}
       ]);
-      var options = grunt.util._.extend.apply(null, args);
-      grunt.verbose.writeflags(options, 'Options');
-      return options;
+      return grunt.util._.extend.apply(null, args);
     };
     // Expose data on `this` (as well as task.current).
     this.data = grunt.config([name, target]);
@@ -295,6 +296,10 @@ task.runAllTargets = function(taskname, args) {
   }
   // Iterate over all valid target properties, running a task for each.
   targets.filter(isValidMultiTaskTarget).forEach(function(target) {
+    if ((grunt.option(taskname+':'+target) === false) || (grunt.option(taskname+'-'+target) === false)) {
+      grunt.verbose.write('Task run deactivated.').ok();
+      return;
+    }
     // Be sure to pass in any additionally specified args.
     task.run([taskname, target].concat(args || []).join(':'));
   });


### PR DESCRIPTION
The use case supported by this commit is to disable the running of specific tasks.

An example is better. Given this Gruntfile:

```
'use strict';

module.exports = function(grunt) {
  grunt.file.setBase('../fixtures/files');

  grunt.initConfig({
    a: function () {
      grunt.log.writeln('task a run');
    },
    b: function () {
      grunt.log.writeln('task b run');
    },
    c: function () {
      grunt.log.writeln('task c run');
    },
    log: {
      foo: [1, 2, 3],
      bar: 'hello world',
      baz: false
    }
  });

  grunt.registerTask('build', [
    'a',
    'b',
    'c'
  ]);

  grunt.registerMultiTask('log', 'Log stuff.', function() {
    grunt.log.writeln(this.target + ': ' + this.data);
  });  

  grunt.registerMultiTask('default', [
    'build',
    'log'
  ]);    
```

Running the following : 

```
grunt build --no-b
```

will output: 

```
task a run
task c run
```

```
grunt log --no-log-bar
```

will output: 

```
foo: 1,2,3
baz: false
```

It is also possible to deactive task from multi task:

```
grunt --no-log-bar --no-b
```

will run default task

```
task a run
task c run
foo: 1,2,3
baz: false
```
