### PR TITLE
Current directory value can't be accessed by grunt tasks

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -422,6 +422,8 @@ task.init = function(tasks, options) {
   var msg = 'Reading "' + (gruntfile ? path.basename(gruntfile) : '???') + '" Gruntfile...';
   if (gruntfile && grunt.file.exists(gruntfile)) {
     grunt.verbose.writeln().write(msg).ok();
+    // Store original working directory.
+    grunt.option('originalBase', process.cwd());
     // Change working directory so that all paths are relative to the
     // Gruntfile's location (or the --base option, if specified).
     process.chdir(grunt.option('base') || path.dirname(gruntfile));


### PR DESCRIPTION
Grunt normalizes the base path to the Gruntfile path, changing the `process.cwd()` for all tasks, after this normalization is not possible to find the original `process.cwd()` value from where the grunt task was run.

This issue proposes the addition of a `originalBase` read only option to store the original `process.cwd()` value.
