### PR TITLE
exposed alias property on task._tasks[name].fn.alias

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -81,6 +81,8 @@ task.registerTask = function(name) {
     // Actually run the task.
     return _fn.apply(this, arguments);
   };
+  // Expose alias property
+  thisTask.fn.alias = _fn.alias;
   return task;
 };
 


### PR DESCRIPTION
exposing the alias property on registerTask.

While writing a contrib for helping run tasks, I ran into an issue that I could not differentiate a task that would queue, vs a task that would execute.
