### PR TITLE
Allow processes requiring grunt directly to define the root from where to load npm modules

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -370,7 +370,7 @@ task.loadTasks = function(tasksdir) {
 
 // Load tasks and handlers from a given locally-installed Npm module (installed
 // relative to the base dir).
-task.loadNpmTasks = function(name,root) {
+task.loadNpmTasks = function(name, root) {
   loadTasksMessage('"' + name + '" local Npm module');
   root = root || path.resolve('node_modules');
   var pkgfile = path.join(root, name, 'package.json');


### PR DESCRIPTION
This pull request allows external processes to define where grunt should load its Npm modules from.

The use case is a set of buildtools for a web development framework, which also provides a live development environment for which I want to use grunt as taskrunner, but wrapped inside these buildtools. A Gruntfile is not used. The configuration is detected by the buildtools from scanning the project folder in combination with using a custom format and injected in grunt.

Because these buildtools need to be installable globally with a single npm, the grunt plugins used should be installed and included from this buildtools npm, and not inside the project itself and only be installed once for the entire system in order to ensure compatibility. This is not currently possible with grunt, as the root folder for where grunt loads the npm modules from is always the current project folder, and not the node_modules folder in where the buildtools are installed. This PR fixes this by adding a parameter to loadNpmTasks which sets the root folder of the npm module to load instead of detecting it automatically.
