### PR TITLE
Fix sub-Grunt cmd path for portable Node installs.

### DIFF
--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -149,8 +149,8 @@ util.spawn = function(opts, done) {
   var cmd, args;
   var pathSeparatorRe = /[\\\/]/g;
   if (opts.grunt) {
-    cmd = process.argv[0];
-    args = [process.argv[1]].concat(opts.args);
+    cmd = process.execPath;
+    args = process.execArgv.concat(process.argv[1], opts.args);
   } else {
     // On Windows, child_process.spawn will only file .exe files in the PATH,
     // not other executable types (grunt issue #155).


### PR DESCRIPTION
Closes gh-980.

Tested on Windows 7 both with Node.js only installed "portably" as well as installed globally.  Fixed the issue I was having, and seems to continue working for the existing tests.  This change isn't really possible to add unit tests for without including a portable copy of Node in the repo or else downloading it for each build, so I've left verification to your existing `subgrunt` task (which passes).

Related Node documentation for quick reference:  [process.execPath](http://nodejs.org/api/process.html#process_process_execpath) and [process.argv](http://nodejs.org/api/process.html#process_process_argv) 

Let me know if you have any other questions.  I'd love to see this go out as a 0.4.2 point fix soon so I don't have to keep my fork in our build system for long. Thanks! :metal:
