### PR TITLE
Remove the words 'without errors.' after successfully running tasks

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -79,6 +79,6 @@ fail.report = function() {
   if (fail.warncount > 0) {
     grunt.log.writeln().fail('Done, but with warnings.');
   } else {
-    grunt.log.writeln().success('Done, without errors.');
+    grunt.log.writeln().success('Done.');
   }
 };


### PR DESCRIPTION
The presence of the word errors causes automated build result processing to present a false positive for failure.  It is commonplace for automation frameworks to look for the presence of the word "error" or "errors." Simply parsing the message in the log output often causes alarm within our organization.

Please consider this change.