### PR TITLE
grunt.loadNpmTasks now supports Array argument.

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -370,38 +370,41 @@ task.loadTasks = function(tasksdir) {
 
 // Load tasks and handlers from a given locally-installed Npm module (installed
 // relative to the base dir).
-task.loadNpmTasks = function(name) {
-  loadTasksMessage('"' + name + '" local Npm module');
+task.loadNpmTasks = function(modules) {
+  modules = Array.isArray(modules)? modules : [modules];
   var root = path.resolve('node_modules');
-  var pkgfile = path.join(root, name, 'package.json');
-  var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
+  modules.forEach(function(name) {
+    loadTasksMessage('"' + name + '" local Npm module');
+    var pkgfile = path.join(root, name, 'package.json');
+    var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
 
-  // Process collection plugins.
-  if (pkg.keywords && pkg.keywords.indexOf('gruntcollection') !== -1) {
-    loadTaskDepth++;
-    Object.keys(pkg.dependencies).forEach(function(depName) {
-      // Npm sometimes pulls dependencies out if they're shared, so find
-      // upwards if not found locally.
-      var filepath = grunt.file.findup('node_modules/' + depName, {
-        cwd: path.resolve('node_modules', name),
-        nocase: true
+    // Process collection plugins.
+    if (pkg.keywords && pkg.keywords.indexOf('gruntcollection') !== -1) {
+      loadTaskDepth++;
+      Object.keys(pkg.dependencies).forEach(function(depName) {
+        // Npm sometimes pulls dependencies out if they're shared, so find
+        // upwards if not found locally.
+        var filepath = grunt.file.findup('node_modules/' + depName, {
+          cwd: path.resolve('node_modules', name),
+          nocase: true
+        });
+        if (filepath) {
+          // Load this task plugin recursively.
+          task.loadNpmTasks(path.relative(root, filepath));
+        }
       });
-      if (filepath) {
-        // Load this task plugin recursively.
-        task.loadNpmTasks(path.relative(root, filepath));
-      }
-    });
-    loadTaskDepth--;
-    return;
-  }
+      loadTaskDepth--;
+      return;
+    }
 
-  // Process task plugins.
-  var tasksdir = path.join(root, name, 'tasks');
-  if (grunt.file.exists(tasksdir)) {
-    loadTasks(tasksdir);
-  } else {
-    grunt.log.error('Local Npm module "' + name + '" not found. Is it installed?');
-  }
+    // Process task plugins.
+    var tasksdir = path.join(root, name, 'tasks');
+    if (grunt.file.exists(tasksdir)) {
+      loadTasks(tasksdir);
+    } else {
+      grunt.log.error('Local Npm module "' + name + '" not found. Is it installed?');
+    }
+  });
 };
 
 // Initialize tasks.


### PR DESCRIPTION
Now, you can do:

``` javascript
grunt.loadNpmTasks([
  'grunt-contrib-coffee'
  'grunt-contrib-compass'
  'grunt-contrib-connect'
  'grunt-contrib-copy'
  'grunt-contrib-jade'
  'grunt-contrib-watch'
  'grunt-contrib-clean'
]);
```

Basically, I wrapped the stuff that was in `task.loadNpmTasks` in a for loop. If the argument is not an array, I stick it in an array. Simple stuff!
