### PR TITLE
lowercase extension .md in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,6 @@ test
 .travis.yml
 AUTHORS
 CHANGELOG
-CONTRIBUTING.MD
+CONTRIBUTING.md
 custom-gruntfile.js
 Gruntfile.js


### PR DESCRIPTION
tiny typo

tested with `npm pack`
