### PR TITLE
Trigger events on fatal and warn

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -53,6 +53,7 @@ function dumpStack(e) {
 // A fatal error occurred. Abort immediately.
 fail.fatal = function(e, errcode) {
   writeln(e, 'fatal');
+  grunt.event.emit('fatal', e, errcode);
   dumpStack(e);
   grunt.util.exit(typeof errcode === 'number' ? errcode : fail.code.FATAL_ERROR);
 };
@@ -66,6 +67,7 @@ fail.warn = function(e, errcode) {
   var message = typeof e === 'string' ? e : e.message;
   fail.warncount++;
   writeln(message, 'warn');
+  grunt.event.emit('warn', e, errcode);
   // If -f or --force aren't used, stop script processing.
   if (!grunt.option('force')) {
     dumpStack(e);


### PR DESCRIPTION
Sometimes when task spawns other tasks, we need to have an ability to react somehow to their failure.
So, I simply trigger event `warn` on warn failure and `fatal` on fatal faliure.
For example,

``` js
grunt.event.on('warn', function() {
  fs.unlink(util.buildFolder());
  grunt.log.writeln('ERROR -- build folder removed');
});
```
