### PR TITLE
"Ext" replacement (with expand) breaks on filenames that contain a dot

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -151,7 +151,7 @@ file.expandMapping = function(patterns, destBase, options) {
     }
     // Change the extension?
     if (options.ext) {
-      destPath = destPath.replace(/(\.[^\/]*)?$/, options.ext);
+      destPath = destPath.replace(/(\.[^\/.]*)?$/, options.ext);
     }
     // Generate destination filename.
     var dest = options.rename(destBase, destPath, options);


### PR DESCRIPTION
Have the following files:
`$ ls bug/
a.b.js   a.js   b.js`

Now:

```
    grunt.registerMultiTask('test', 'whatever', function() {
      this.files.forEach(function(f){
        console.warn(f.src, f.dest);
      });
    });

    grunt.config('test.build1', {
      files: [{
        expand: true,
        cwd: 'bug',
        src: ['**/*.js'],
        filter: 'isFile',
        dest: 'bar'
      }]
    });

    grunt.config('test.build2', {
      files: [{
        expand: true,
        cwd: 'bug',
        src: ['**/*.js'],
        filter: 'isFile',
        dest: 'bar',
        ext: 'whatever'
      }]
    });
```

`grunt test.build1`

outputs the expected:

`[ 'bug/a.b.js' ] 'bar/a.b.js'
[ 'bug/a.js' ] 'bar/a.js'
[ 'bug/b.js' ] 'bar/b.js'`

while 
`grunt test.build2`

outputs:
`[ 'bug/a.b.js', 'bug/a.js' ] 'bar/awhatever'
[ 'bug/b.js' ] 'bar/bwhatever'`

... which will result in concatenating a.js and a.b.js into awhatever (which IMHO is not expected).

Proposed patch fixes this.
