### PR TITLE
Make all tasks asynchronous to reduce call stack

### DIFF
--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -212,7 +212,9 @@
       if (!success && this._options.error) {
         this._options.error.call({name: context.name, nameArgs: context.nameArgs}, err);
       }
-      done(err, success);
+      process.nextTick(function () {
+        done(err, success);
+      });
     }.bind(this);
 
     // When called, sets the async flag and returns a function that can


### PR DESCRIPTION
I'm having a weird error when running grunt with lot of tasks (~500).

The issue happens while running grunt-uglify but the root cause is the high number of multi tasks.

```
[RangeError: Maximum call stack size exceeded]
>> Uglifying source "rtl/dist/widget.history.unpack.js" failed.
Warning: Uglification failed.
Maximum call stack size exceeded. 
 Use --force to continue.
Aborted due to warnings.
```

With this pull request all tasks are now asynchronous and next task will run in a 'new' stack after the next tick.

This is very similar to gruntjs/grunt-contrib-imagemin#132
