### PR TITLE
separate suppressOutput config out to the log obj

### DIFF
--- a/lib/grunt/log.js
+++ b/lib/grunt/log.js
@@ -69,7 +69,7 @@ function format(args) {
 function write(msg) {
   msg = msg || '';
   // Actually write output.
-  if (!log.muted && !suppressOutput) {
+  if (!log.muted) {
     hasLogged = true;
     // Users should probably use the colors-provided methods, but if they
     // don't, this should strip extraneous color codes.
@@ -205,16 +205,22 @@ Object.keys(log).filter(function(key) {
   // IS NOT set.
   log.verbose[key] = function() {
     suppressOutput = !grunt.option('verbose');
-    log[key].apply(log, arguments);
-    suppressOutput = false;
+    if(!suppressOutput)
+    {
+      log[key].apply(log, arguments);
+    }
+    //suppressOutput = false;
     return log.verbose;
   };
   // Like any other log function, but suppresses output if the "verbose" option
   // IS set.
   log.notverbose[key] = function() {
     suppressOutput = grunt.option('verbose');
-    log[key].apply(log, arguments);
-    suppressOutput = false;
+    if(!suppressOutput)
+    {
+      log[key].apply(log, arguments); 
+    }
+    //suppressOutput = false;
     return log.notverbose;
   };
 });


### PR DESCRIPTION
## 1: fix issues like this:

when i add hooker to grunt.log.writeln function, but the verbose.writeln's supperssOutput config judge at the grunt.log.writeln.
so i got the grunt.verbose.writeln's  log message when i did'n want this;
example code : 

```
   hooker.hook(grunt.log, 'writeln', {
    pre : function(){
        console.log('grunt.log.writeln:' + arguments[0]);
    }
   });
```

2: commit reset suppressOutput, as it don't change when the task run. i want to know why?
