### PR TITLE
Added to grunt the hideTask() method

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -114,6 +114,14 @@ grunt.tasks = function(tasks, options, done) {
   // Initialize tasks.
   task.init(tasks);
 
+  // Bail out if any of the given tasks is hidden.
+  var firstHiddenTaskName = grunt.util._.detect(tasks, function(name){
+    return task.isTaskHidden(name);
+  });
+  if(firstHiddenTaskName) {
+    fail.warn(new Error('Task "' + firstHiddenTaskName + '" not found.'));
+  }
+
   verbose.writeln();
   if (!tasksSpecified) {
     verbose.writeln('No tasks specified, running default tasks.');

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -89,22 +89,6 @@ function isValidMultiTaskTarget(target) {
   return !/^_|^options$/.test(target);
 }
 
-task.isTaskHidden = function(name) {
-  return !!task._hiddenTasks[name];
-};
-
-task.availableTasks = function() {
-  var _ = grunt.util._;
-  var taskNames = _.keys(task._tasks);
-  var result = {};
-  taskNames.filter(function(t) {
-    return !task.isTaskHidden(t);
-  }).forEach(function(name){
-    result[name] = task._tasks[name];
-  });
-  return result;
-};
-
 // Normalize multi task files.
 task.normalizeMultiTaskFiles = function(data, target) {
   var prop, obj;
@@ -289,12 +273,6 @@ task.registerMultiTask = function(name, info, fn) {
 task.registerInitTask = function(name, info, fn) {
   task.registerTask(name, info, fn);
   task._tasks[name].init = true;
-};
-
-// Hides the task from the user and also making sure it can't be executed.
-task.hideTask = function(name) {
-  // Add log?
-  task._hiddenTasks[name] = task._tasks[name];
 };
 
 // Override built-in renameTask to use the registry.

--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -53,6 +53,29 @@
     }
   };
 
+  Task.prototype.isTaskHidden = function(name) {
+    return !!this._hiddenTasks[name];
+  };
+
+  Task.prototype.availableTasks = function() {
+    var taskNames = Object.keys(this._tasks);
+    var result = {};
+    taskNames.filter(function(t) {
+      return !this.isTaskHidden(t);
+    }, this).forEach(function(name){
+      result[name] = this._tasks[name];
+    }, this);
+    return result;
+  };
+
+  // Hides the task from the user and also making sure it can't be executed.
+  Task.prototype.hideTask = function(name) {
+    var taskToHide = this._tasks[name];
+    if (!taskToHide) { return; }
+
+    this._hiddenTasks[name] = taskToHide;
+  };
+
   // Register a new task.
   Task.prototype.registerTask = function(name, info, fn) {
     // If optional "info" string is omitted, shuffle arguments a bit.
@@ -168,7 +191,8 @@
     // Parse arguments into an array, returning an array of task+args objects.
     var things = this.parseArgs(arguments).map(this._taskPlusArgs, this);
     // Throw an exception if any tasks weren't found.
-    var fails = things.filter(function(thing) { return !thing.task || this.isTaskHidden(thing.task.name); }, this);
+    var fails = things.filter(function(thing) { return !thing.task; });
+
     if (fails.length > 0) {
       this._throwIfRunning(new Error('Task "' + fails[0].nameArgs + '" not found.'));
       return this;

--- a/test/util/task_test.js
+++ b/test/util/task_test.js
@@ -59,6 +59,48 @@ exports['Tasks'] = {
     });
     task.run('y', 'z').start();
   },
+  'Task#isTaskHidden': function(test) {
+    test.expect(2);
+    var task = this.task;
+    task.registerTask('a', 'This task should not be visible', result.pushTaskname);
+    task.registerTask('b', 'This task should be visible', result.pushTaskname);
+    task.hideTask('a');
+    test.equal(task.isTaskHidden('a'), true, 'It should be a hidden task');
+    test.equal(task.isTaskHidden('b'), false, 'It should not be a hidden task');
+    test.done();
+  },
+  'Task#hideTask': function(test) {
+    test.expect(3);
+    var task = this.task;
+    task.hideTask('a');
+    test.equal('a' in task._hiddenTasks, false, "It should not hide a task that's not registered");
+    task.registerTask('b', 'This task should be visible', result.pushTaskname);
+    test.equal('b' in task._hiddenTasks, false, "It should not hide a task that wasn't hidden");
+    task.registerTask('c', 'This task should not be visible', result.pushTaskname);
+    task.hideTask('c');
+    test.equal('c' in task._hiddenTasks, true, "It should hide a task that's registered & hidden");
+    test.done();
+  },
+  "Task#availableTasks": function(test) {
+    test.expect(3);
+    var task = this.task;
+    var availableTasksCount = Object.keys(task.availableTasks()).length;
+    var allTasksCount = Object.keys(task._tasks).length;
+    test.equal(availableTasksCount, allTasksCount, 'It should start with matching tasks count');
+
+    task.registerTask('a', 'This task should be visible', result.pushTaskname);
+    availableTasksCount = Object.keys(task.availableTasks()).length;
+    allTasksCount = Object.keys(task._tasks).length;
+    test.equal(availableTasksCount, allTasksCount, 'It should have matching tasks count after registering a task');
+
+    task.registerTask('b', 'This task should be visible', result.pushTaskname);
+    task.hideTask('b');
+    availableTasksCount = Object.keys(task.availableTasks()).length;
+    allTasksCount = Object.keys(task._tasks).length;
+    test.equal(availableTasksCount, allTasksCount - 1, 'It should not match tasks count but it should be off by 1');
+
+    test.done();
+  },
   'Task#isTaskAlias': function(test) {
     test.expect(2);
     var task = this.task;


### PR DESCRIPTION
The **hideTask** method allows the user to hide tasks he doesn't want to externalise to the user. The task could still be used by the user for queue'ing in other tasks.
When using the method on a registered task, the task becomes invisible to a user through `grunt -h` or `grunt --verbose --version`, and if for any
reason he wishes to execute it through the CLI, he'll get the same warning he would get for executing a task that doesn't exist.

I've added 3 new methods to Task, only hideTask is exposed:
**hideTask**: (name) - Allows the user to internalise a task, making it executable from inside grunt but not executable from the CLI.
    - **name** - The name of the registered task.
**isTaskHidden**: (name) - Returns a boolean whether the registered task is hidden or not.
    - **name** - The name of the registered task.
**availableTasks**: Returns an object without the tasks that are hidden.

I'm also using an internal variable `_hiddenTasks`, to keep track of which tasks were hidden.

**_Things that aren't covered by the PR**_
- I didn't write tests that ensure the task isn't displayed in `grunt -h` or `grunt --version --verbose`.
- I didn't write tests that ensure that a user can't execute a hidden task.

Since this PR is based on an issue (#910) that's not marked as **Needs PR**, I hope it will shed some more light into this issue, in hopes of getting something like this into grunt in the future.

As a side note I wish to use this feature in https://github.com/BlueHotDog/sails-migrations, where we used grunt to externalise db migration tasks, but we have internal tasks which we wish not to externalise to the user. Since grunt doesn't have a way to register a task with a dependency that is run before the task itself, we needed to create these internal tasks, that are later composed into the 'public' task. An example of this is that all tasks need the db:loadConfig task to run before each of 'em, so we've registered an 'internal task' for each of the actual tasks that does it's job, and then registered an external task that queues the db:loadConfig task & the internal task.
