### PR TITLE
Update task.normalizeMultiTaskFiles to flatten data.files if array

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -107,7 +107,7 @@ task.normalizeMultiTaskFiles = function(data, target) {
         files.push({src: data.files[prop], dest: grunt.config.process(prop)});
       }
     } else if (Array.isArray(data.files)) {
-      data.files.forEach(function(obj) {
+      grunt.util._.flatten(data.files).forEach(function(obj) {
         var prop;
         if ('src' in obj || 'dest' in obj) {
           files.push(obj);

--- a/test/gruntfile/multi-task-files.js
+++ b/test/gruntfile/multi-task-files.js
@@ -90,6 +90,19 @@ module.exports = function(grunt) {
           }
         ]
       },
+      long4_mapping: {
+        options: {a: 8, c: 88},
+        files: [
+          '<%= run.long3_mapping.files %>'
+        ]
+      },
+      long5_mapping: {
+        options: {a: 9, c: 99},
+        files: [
+          '<%= run.long3_mapping.files %>',
+          '<%= run.long4_mapping.files %>'
+        ]
+      },
       // Need to ensure the task function is run if no files or options were
       // specified!
       no_files_or_options: {},
@@ -294,6 +307,94 @@ module.exports = function(grunt) {
         },
       ],
     },
+    'run:long4_mapping': {
+      options: {a: 8, b: 11, c: 88, d: 9},
+      files: [
+        {
+          dest: 'foo/baz/file1.bar',
+          src: ['src/file1.js'],
+          extra: 123,
+          orig: {
+            expand: true,
+            cwd: grunt.config.get('mappings.cwd'),
+            src: ['*1.js', '*2.js'],
+            dest: grunt.config.get('mappings.dest'),
+            rename: grunt.config.get('mappings.rename'),
+            extra: 123,
+          },
+        },
+        {
+          dest: 'foo/baz/file2.bar',
+          src: ['src/file2.js'],
+          extra: 123,
+          orig: {
+            expand: true,
+            cwd: grunt.config.get('mappings.cwd'),
+            src: ['*1.js', '*2.js'],
+            dest: grunt.config.get('mappings.dest'),
+            rename: grunt.config.get('run.built_mapping.rename'),
+            extra: 123,
+          },
+        },
+      ],
+    },
+    'run:long5_mapping': {
+      options: {a: 9, b: 11, c: 99, d: 9},
+      files: [
+        {
+          dest: 'foo/baz/file1.bar',
+          src: ['src/file1.js'],
+          extra: 123,
+          orig: {
+            expand: true,
+            cwd: grunt.config.get('mappings.cwd'),
+            src: ['*1.js', '*2.js'],
+            dest: grunt.config.get('mappings.dest'),
+            rename: grunt.config.get('mappings.rename'),
+            extra: 123,
+          },
+        },
+        {
+          dest: 'foo/baz/file2.bar',
+          src: ['src/file2.js'],
+          extra: 123,
+          orig: {
+            expand: true,
+            cwd: grunt.config.get('mappings.cwd'),
+            src: ['*1.js', '*2.js'],
+            dest: grunt.config.get('mappings.dest'),
+            rename: grunt.config.get('run.built_mapping.rename'),
+            extra: 123,
+          },
+        },
+        {
+          dest: 'foo/baz/file1.bar',
+          src: ['src/file1.js'],
+          extra: 123,
+          orig: {
+            expand: true,
+            cwd: grunt.config.get('mappings.cwd'),
+            src: ['*1.js', '*2.js'],
+            dest: grunt.config.get('mappings.dest'),
+            rename: grunt.config.get('mappings.rename'),
+            extra: 123,
+          },
+        },
+        {
+          dest: 'foo/baz/file2.bar',
+          src: ['src/file2.js'],
+          extra: 123,
+          orig: {
+            expand: true,
+            cwd: grunt.config.get('mappings.cwd'),
+            src: ['*1.js', '*2.js'],
+            dest: grunt.config.get('mappings.dest'),
+            rename: grunt.config.get('run.built_mapping.rename'),
+            extra: 123,
+          },
+        },
+      ],
+    },
   };
 
   var assert = require('assert');
@@ -353,6 +454,10 @@ module.exports = function(grunt) {
     'test:built_mapping',
     'run:long3_mapping',
     'test:long3_mapping',
+    'run:long4_mapping',
+    'test:long4_mapping',
+    'run:long5_mapping',
+    'test:long5_mapping',
     'run',
     'test:all',
     'test:counters',


### PR DESCRIPTION
Created PR for [issue 1033](https://github.com/gruntjs/grunt/issues/1033):

Given a config snippet of:

``` javascript
copy: {
    build_web: {
        files: [
            {
                // robots.txt, favicon.ico, etc
                expand: true,
                flatten: true,
                cwd: '<%= config.web.src.dir %>',
                dest: '<%= config.web.build.dir %>',
                src: [ '*.{ico,txt}' ]
            },
            {
                // App JavaScript files
                expand: true,
                flatten: true,
                cwd: '<%= config.web.src.dir %>',
                dest: '<%= config.web.build.dir %>scripts/',
                src: [ 'scripts/**/*.js' ]
            },
            {
                // App minified 3rd party JavaScript files
                expand: true,
                flatten: true,
                cwd: '<%= config.web.src.dir %>',
                dest: '<%= config.web.build.dir %>scripts/components/',
                src: [ 'components/**/*.min.js' ]
            },
        ]
    },
    build_server: {
        files: [
            {
                expand: true,
                cwd: '<%= config.server.src.dir %>',
                dest: '<%= config.server.build.dir %>',
                src: [ '**/*' ]
            }
        ]
    },
    build_all: {
        files: [
          '<%= copy.build_web.files %>',
          '<%= copy.build_server.files %>'
        ]
    }
}
```

Task `copy:build_all` will fail with:
`Warning: Object #<Object> has no method 'indexOf' Use --force to continue.`

The issue stems from not flattening the data.files array prior to looping through the multidimensional array that is passed in.
