### PR TITLE
Added the Grunt config merge function

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -50,6 +50,7 @@ gExpose(task, 'renameTask');
 gExpose(task, 'loadTasks');
 gExpose(task, 'loadNpmTasks');
 gExpose(config, 'init', 'initConfig');
+gExpose(config, 'merge', 'mergeConfig');
 gExpose(fail, 'warn');
 gExpose(fail, 'fatal');
 

--- a/lib/grunt/config.js
+++ b/lib/grunt/config.js
@@ -88,6 +88,14 @@ config.init = function(obj) {
   return (config.data = obj || {});
 };
 
+// Merge data with existing config data.
+config.merge = function(obj) {
+  grunt.verbose.write('Merging config...').ok();
+  // Merge the existing config data.
+  grunt.util._.merge(config.data, obj);
+  return config.data;
+};
+
 // Test to see if required config params have been defined. If not, throw an
 // exception (use this inside of a task).
 config.requires = function() {

--- a/test/grunt/config_test.js
+++ b/test/grunt/config_test.js
@@ -107,4 +107,24 @@ exports['config'] = {
     grunt.log.muted = false;
     test.done();
   },
+  'config.merge': function(test) {
+
+    grunt.config.merge({
+      foo2: '<%= foo %> merged',
+      fooNew: '<%= foo2 %> new',
+      obj: {
+        foo2: '<%= obj.foo %> merged',
+        fooNew: '<%= obj.foo2 %> new',
+      },
+    });
+
+    test.expect(6);
+    test.equal(grunt.config.get('foo'), 'bar', 'Should leave original data.');
+    test.equal(grunt.config.get('foo2'), 'bar merged', 'Should override existing data.');
+    test.equal(grunt.config.get('fooNew'), 'bar merged new', 'Should add new data.');
+    test.equal(grunt.config.get('obj.foo'), 'bar', 'Should leave original data.');
+    test.equal(grunt.config.get('obj.foo2'), 'bar merged', 'Should override existing data.');
+    test.equal(grunt.config.get('obj.fooNew'), 'bar merged new', 'Should add new data data.');
+    test.done();
+  },
 };


### PR DESCRIPTION
I added a simple method, `grunt.config.merge` (and alias, `grunt.mergeConfig`).
It behaves exactly as `grunt.initConfig`, but it allows the config object to be split into separate parts, or even separate files.

I've been using this to organize my grunt configurations by feature.  For example, I have sections like "desktop-javascripts", "mobile-javascripts", and "html templates".  Even though these features require overlapping tasks, the merge function allows them to be separated into more logical groupings.
