### PR TITLE
Use findup to load NPM tasks to match node module resolution conventions

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -373,7 +373,12 @@ task.loadTasks = function(tasksdir) {
 task.loadNpmTasks = function(name) {
   loadTasksMessage('"' + name + '" local Npm module');
   var root = path.resolve('node_modules');
-  var pkgfile = path.join(root, name, 'package.json');
+
+  var moduledir = grunt.file.findup('node_modules/' + name, {
+    nocase: true
+  });
+
+  var pkgfile = path.join(moduledir, 'package.json');
   var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
 
   // Process collection plugins.
@@ -396,7 +401,7 @@ task.loadNpmTasks = function(name) {
   }
 
   // Process task plugins.
-  var tasksdir = path.join(root, name, 'tasks');
+  var tasksdir = path.join(moduledir, 'tasks');
   if (grunt.file.exists(tasksdir)) {
     loadTasks(tasksdir);
   } else {


### PR DESCRIPTION
Hi! Ran into something that I think is a bug in Grunt, but I don't know the project well enough to say for sure.

When node loads local modules, it looks in ./node_modules, then ../node_modules, then ../../node_modules, etc. However, Grunt does not mimic this behavior when it attempts to load tasks within modules, which breaks that convention.

This pull request is an attempt to fix that. I wasn't sure of the proper way to do it, but this works for me. There might be a better way, though.
