### PR TITLE
User should be notified in case he has not specified any targets BUT has specified task-level options

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -289,7 +289,7 @@ task.runAllTargets = function(taskname, args) {
   // Get an array of sub-property keys under the given config object.
   var targets = Object.keys(grunt.config.getRaw(taskname) || {});
   // Fail if there are no actual properties to iterate over OR if there are only task-level options, which means there are no targets to be run.
-  if ((targets.length === 0) || (targets.length === 1 && targets[0].toUpperCase() == 'OPTIONS')) {
+  if ((targets.length === 0) || (targets.length === 1 && targets[0].toUpperCase() === 'OPTIONS')) {
     grunt.log.error('No "' + taskname + '" targets found.');
     return false;
   }


### PR DESCRIPTION
If you specify a task with only task-level options but no targets, e.g.:

```
mytask: {
  options: {
    stuff: 'things';
  }
}
```

Grunt should tell you that no targets were found, which is not the case.

HOWEVER, when you do the following, it actually errors out saying 'No "mytask" toggles targets found.':

```
mytask: {
}
```

The behaviour for the two snippets shown above should be consistent (i.e. informing the user that no targets are available.)
