### PR TITLE
Replaced regex with path methods for dynamic destPath

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -151,7 +151,7 @@ file.expandMapping = function(patterns, destBase, options) {
     }
     // Change the extension?
     if (options.ext) {
-      destPath = destPath.replace(/(\.[^\/]*)?$/, options.ext);
+      destPath = path.basename( destPath, path.extname(destPath) ) + options.ext;
     }
     // Generate destination filename.
     var dest = options.rename(destBase, destPath, options);


### PR DESCRIPTION
The regex used to strip out the extension for dynamic path names removes everything after the first period. This change takes advantage of node path methods instead, which has the effect of only stripping out only things after the last period. For example, given `options.ext === '.min.js'`:

With the old code, `some.long.filename.js` would become `some.min.js` after being parsed by the regex. The new function would return `some.long.filename.min.js`.

I intentionally didn't update the unit tests; I just wanted to see if there was any interest in this change first.

This behavior led to [this issue](https://github.com/gruntjs/grunt-contrib-uglify/issues/157).
