### PR TITLE
Add sensible default for optional args in grunt.utils#spawn

### DIFF
--- a/lib/grunt/util.js
+++ b/lib/grunt/util.js
@@ -165,7 +165,7 @@ util.spawn = function(opts, done) {
       callDone(127, '', String(err));
       return;
     }
-    args = opts.args;
+    args = opts.args || [];
   }
 
   var child = spawn(cmd, args, opts.opts);


### PR DESCRIPTION
Hi, 

Due to changes in Node’s `child_process spawn` for version 0.10.25 (see [changelog](http://nodejs.org/changelog.html) and the specific [commit](https://github.com/joyent/node/commit/67e9298fb6509d5f6ad2f7e67620a2d82549a1e8)) `grunt.utils#spawn` needs to be changed to also reflect these changes.

This popped up in issue #1062 as build failed in 0.10 and was not related to the PR itself. The tests failed in [uitls_test.js](https://github.com/gruntjs/grunt/blob/master/test/grunt/util_test.js#L199) where `grunt.utils#spawn` are no args passed.

![bildschirmfoto 2014-02-19 um 09 43 55](https://f.cloud.github.com/assets/710639/2205438/dcbd8814-994f-11e3-9caf-9367ebefd803.png)
![bildschirmfoto 2014-02-19 um 09 43 21](https://f.cloud.github.com/assets/710639/2205439/dcbda682-994f-11e3-93d1-7b248b56ae68.png)
