### PR TITLE
fix: return `--field` instead of `--field=undefined` in grunt.option.flags() if the the option's value is undefined....

### DIFF
--- a/lib/grunt/option.js
+++ b/lib/grunt/option.js
@@ -37,6 +37,7 @@ option.flags = function() {
   }).map(function(key) {
     var val = data[key];
     return '--' + (val === false ? 'no-' : '') + key +
-      (typeof val === 'boolean' ? '' : '=' + val);
+      (typeof val === 'boolean' ? '' :
+        (typeof val === 'undefined' ? '' : '=' + val));
   });
 };

--- a/test/grunt/option_test.js
+++ b/test/grunt/option_test.js
@@ -28,14 +28,16 @@ exports['option'] = {
     test.done();
   },
   'option.flags': function(test) {
+    var und;
     test.expect(1);
     grunt.option.init({
       foo: 'bar',
       there: true,
       obj: {foo: 'bar'},
-      arr: []
+      arr: [],
+      und: und
     });
-    test.deepEqual(grunt.option.flags(), ['--foo=bar', '--there', '--obj=[object Object]']);
+    test.deepEqual(grunt.option.flags(), ['--foo=bar', '--there', '--obj=[object Object]', '--und']);
     test.done();
   },
 };


### PR DESCRIPTION
fixes #1066
