### PR TITLE
Add symlink option to grunt.file.copy

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -305,6 +305,19 @@ file.copy = function(srcpath, destpath, options) {
   // If the file will be processed, use the encoding as-specified. Otherwise,
   // use an encoding of null to force the file to be read/written as a Buffer.
   var readWriteOptions = process ? options : {encoding: null};
+  // Copy symlinks as symlinks
+  var isLink = fs.lstatSync( srcpath ).isSymbolicLink();
+  if ( isLink ) {
+    var destdir = path.join( destpath, '..' );
+    // Use the correct relative path for the symlink
+    if (!grunt.file.isPathAbsolute(srcpath)) {
+      srcpath = path.relative(destdir, srcpath) || '.';
+    }
+    file.mkdir( destdir );
+    var mode = grunt.file.isDir(srcpath) ? 'dir' : 'file';
+    fs.symlinkSync(srcpath, destpath, mode);
+    return;
+  }
   // Actually read the file.
   var contents = file.read(srcpath, readWriteOptions);
   if (process) {


### PR DESCRIPTION
[Ref](https://github.com/gruntjs/grunt-contrib-copy/pull/131)

~~Actually, I may have misinterpreted that issue in my early-morning sleepiness. The issue is really that it won't copy symlinks. I'll update this PR accordingly.~~

Presently, `grunt.file.copy` will take symlinks and generate new files from them. This change makes it so that symlinks are copied as symlinks.

This first commit is a rough draft showing a really basic implementation of the idea.
