### PR TITLE
If there is a stack on the error object when it is thrown, display it

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -120,7 +120,7 @@ grunt.tasks = function(tasks, options, done) {
 
   // Handle otherwise unhandleable (probably asynchronous) exceptions.
   var uncaughtHandler = function(e) {
-    fail.fatal(e, fail.code.TASK_FAILURE);
+    fail.fatal(e.stack ? e.stack : e, fail.code.TASK_FAILURE);
   };
   process.on('uncaughtException', uncaughtHandler);
 


### PR DESCRIPTION
This fixes the problem where an uncaught exception in Grunt only displays an error message.

In particular, we cannot see the stack at the time of the exception.

Because we can't see the stack, we don't know where the error originated.

This problem is especially pronounced when using something like grunt-contrib-nodeunit to develop a library. Since we are developing, errors occur often and there is no way to easily debug it.

Note: since this is a simple patch, I don't think there are any problems with it; however, I haven't been able to run the tests on my Windows machine. Ironically, I couldn't understand the error message until I put in this change. :) Looks like there is a call to fs.symlinkSync which I'm guessing doesn't work in Windows.
