### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,5 @@ test
 .travis.yml
 AUTHORS
 CHANGELOG
-CONTRIBUTING.md
 custom-gruntfile.js
 Gruntfile.js


### PR DESCRIPTION
Fixes #1092. This file is needed by the [grunt-contrib suite](https://github.com/gruntjs/grunt-contrib-internal/blob/master/tasks/build-contrib.js#L92).
