### PR TITLE
Correct date in changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 v0.4.4:
-  date: 2014-04-12
+  date: 2014-03-12
   changes:
     - Only signal completion of tasks async if grunt.task.start is invoked with `{asyncDone:true}`.
 v0.4.3:


### PR DESCRIPTION
0.4.4 was not, sadly, released in the future.
