### PR TITLE
Use Grunt programmatically from JavaScript 

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -114,7 +114,7 @@ grunt.tasks = function(tasks, options, done) {
   tasks = task.parseArgs([tasksSpecified ? tasks : 'default']);
 
   // Initialize tasks.
-  task.init(tasks);
+  task.init(tasks, {nogruntfile: !!options.nogruntfile});
 
   verbose.writeln();
   if (!tasksSpecified) {

--- a/lib/grunt/cli.js
+++ b/lib/grunt/cli.js
@@ -58,6 +58,10 @@ var optlist = cli.optlist = {
     info: 'Specify an alternate Gruntfile. By default, grunt looks in the current or parent directories for the nearest Gruntfile.js or Gruntfile.coffee file.',
     type: path
   },
+  nogruntfile: {
+    info: 'Disable the Gruntfile.js or Gruntfile.coffee file. Useful when using Grunt programmatically from JavaScript.',
+    type: path
+  },
   debug: {
     short: 'd',
     info: 'Enable debugging mode for tasks that support it.',

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -435,7 +435,7 @@ task.init = function(tasks, options) {
     // Load local tasks, if the file exists.
     loadTasksMessage('Gruntfile');
     loadTask(gruntfile);
-  } else if (options.help || allInit) {
+  } else if (options.help || options.nogruntfile || allInit) {
     // Don't complain about missing Gruntfile.
   } else if (grunt.option('gruntfile')) {
     // If --config override was specified and it doesn't exist, complain.


### PR DESCRIPTION
This fix allows Grunt to be used programmatically from JavaScript without the need for a Gruntfile, like so:

```
var grunt = require('grunt');

grunt.initConfig({
    pkg: {
        "name" : "grunt-prog-test",
        "version" : "0.0.1",
        "devDependencies": {    
            "grunt": "~0.4.2",
            "grunt-contrib-concat": "~0.1.3",
            "grunt-contrib-cssmin" : "~0.6.1"
        }
    },
    concat: {
        css: {
            src: [
                'src/*.css'
            ],
            dest: 'dist/test.css'
        }
    },
    cssmin: {
        css: {
            src: 'dist/test.css',
            dest: 'dist/test.min.css'
        }
    }
});

grunt.loadNpmTasks('grunt-contrib-concat');
grunt.loadNpmTasks('grunt-contrib-cssmin');

grunt.tasks([ 'concat:css', 'cssmin:css' ], { verbose: true, nogruntfile: true }, function () { 
  console.log('done')
});
```
