### PR TITLE
Use svg for build status on travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grunt: The JavaScript Task Runner
 
-[![Build Status: Linux](https://secure.travis-ci.org/gruntjs/grunt.png?branch=master)](http://travis-ci.org/gruntjs/grunt)
+[![Build Status: Linux](https://secure.travis-ci.org/gruntjs/grunt.svg?branch=master)](http://travis-ci.org/gruntjs/grunt)
 <a href="https://ci.appveyor.com/project/gruntjs/grunt"><img src="https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva/branch/master" alt="Build Status: Windows" height="18" /></a>
 [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
 


### PR DESCRIPTION
Howdy.

Thanks for an awesome project. And sorry for this minor pull request, but I can't help but feel an itch when looking at travis icons on a retina display and knowing that they offer an svg version. So if you want to merge this, cool. If not, just keep up the good work. Have a great day! :)
