### PR TITLE
Short is a reserved word

### DIFF
--- a/lib/grunt/cli.js
+++ b/lib/grunt/cli.js
@@ -41,65 +41,65 @@ var cli = module.exports = function(options, done) {
 // Default options.
 var optlist = cli.optlist = {
   help: {
-    short: 'h',
-    info: 'Display this help text.',
-    type: Boolean
+    'short': 'h',
+    'info': 'Display this help text.',
+    'type': Boolean
   },
   base: {
-    info: 'Specify an alternate base path. By default, all file paths are relative to the Gruntfile. (grunt.file.setBase) *',
-    type: path
+    'info': 'Specify an alternate base path. By default, all file paths are relative to the Gruntfile. (grunt.file.setBase) *',
+    'type': path
   },
   color: {
-    info: 'Disable colored output.',
-    type: Boolean,
-    negate: true
+    'info': 'Disable colored output.',
+    'type': Boolean,
+    'negate': true
   },
   gruntfile: {
-    info: 'Specify an alternate Gruntfile. By default, grunt looks in the current or parent directories for the nearest Gruntfile.js or Gruntfile.coffee file.',
-    type: path
+    'info': 'Specify an alternate Gruntfile. By default, grunt looks in the current or parent directories for the nearest Gruntfile.js or Gruntfile.coffee file.',
+    'type': path
   },
   debug: {
-    short: 'd',
-    info: 'Enable debugging mode for tasks that support it.',
-    type: [Number, Boolean]
+    'short': 'd',
+    'info': 'Enable debugging mode for tasks that support it.',
+    'type': [Number, Boolean]
   },
   stack: {
-    info: 'Print a stack trace when exiting with a warning or fatal error.',
-    type: Boolean
+    'info': 'Print a stack trace when exiting with a warning or fatal error.',
+    'type': Boolean
   },
   force: {
-    short: 'f',
-    info: 'A way to force your way past warnings. Want a suggestion? Don\'t use this option, fix your code.',
-    type: Boolean
+    'short': 'f',
+    'info': 'A way to force your way past warnings. Want a suggestion? Don\'t use this option, fix your code.',
+    'type': Boolean
   },
   tasks: {
-    info: 'Additional directory paths to scan for task and "extra" files. (grunt.loadTasks) *',
-    type: Array
+    'info': 'Additional directory paths to scan for task and "extra" files. (grunt.loadTasks) *',
+    'type': Array
   },
   npm: {
-    info: 'Npm-installed grunt plugins to scan for task and "extra" files. (grunt.loadNpmTasks) *',
-    type: Array
+    'info': 'Npm-installed grunt plugins to scan for task and "extra" files. (grunt.loadNpmTasks) *',
+    'type': Array
   },
   write: {
-    info: 'Disable writing files (dry run).',
-    type: Boolean,
-    negate: true
+    'info': 'Disable writing files (dry run).',
+    'type': Boolean,
+    'negate': true
   },
   verbose: {
-    short: 'v',
-    info: 'Verbose mode. A lot more information output.',
-    type: Boolean
+    'short': 'v',
+    'info': 'Verbose mode. A lot more information output.',
+    'type': Boolean
   },
   version: {
-    short: 'V',
-    info: 'Print the grunt version. Combine with --verbose for more info.',
-    type: Boolean
+    'short': 'V',
+    'info': 'Print the grunt version. Combine with --verbose for more info.',
+    'type': Boolean
   },
   // Even though shell auto-completion is now handled by grunt-cli, leave this
   // option here for display in the --help screen.
   completion: {
-    info: 'Output shell auto-completion rules. See the grunt-cli documentation for more information.',
-    type: String
+    'info': 'Output shell auto-completion rules. See the grunt-cli documentation for more information.',
+    'type': String
   },
 };
 


### PR DESCRIPTION
Short is a reserved word in [ECMAScript 2+](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Reserved_Words). As such, it can't be used an identifier, strictly. An easy solution is to put it in quotes. I've done that for the main grunt/cli.js file, as well as the other IDs for conformity's sake. It's not pretty, but it's valid.
