### PR TITLE
extend _.templateSettings instead of overriding it

### DIFF
--- a/lib/grunt/template.js
+++ b/lib/grunt/template.js
@@ -51,7 +51,7 @@ template.setDelimiters = function(name) {
   // Get the appropriate delimiters.
   var delimiters = allDelimiters[name in allDelimiters ? name : 'config'];
   // Tell Lo-Dash which delimiters to use.
-  grunt.util._.templateSettings = delimiters.lodash;
+  grunt.util._.extend(grunt.util._.templateSettings, delimiters.lodash);
   // Return the delimiters.
   return delimiters;
 };


### PR DESCRIPTION
This resolves "_ is not defined" errors when using templates.

See also: https://github.com/lodash/lodash/issues/484