### PR TITLE
try to load main file of npm task

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -407,19 +407,19 @@ task.loadNpmTasks = function(name) {
   if (grunt.file.exists(tasksdir)) {
     loadTasks(tasksdir);
   } else {
-    var notFound = function() {
-      grunt.log.error('Local Npm module "' + name + '" not found. Is it installed?');
-    };
-
     if (pkg.main) {
+      // make sure the main entry point is a valid filename
+      if (!/\.js|\.coffee$/.test(pkg.main)) {
+        pkg.main = pkg.main + '.js';
+      }
       var taskFile = path.join(root, name, pkg.main);
       if (grunt.file.exists(taskFile)) {
         loadTask(taskFile);
       } else {
-        notFound();
+        grunt.log.error('Local Npm module "' + name + '" is installed but could not find task file');
       }
     } else {
-      notFound();
+      grunt.log.error('Local Npm module "' + name + '" not found. Is it installed?');
     }
   }
 };


### PR DESCRIPTION
If a plugin doesn't follow the convention of putting their plugin file in the `tasks` directory of the module, it fails to load. This change tries to load the entry point defined in the module's [main](https://www.npmjs.org/doc/json.html#main) field. 

---

I say "convention" because there's no mention of needing to use this structure in the [Creating plugins](http://gruntjs.com/creating-plugins) documentation. Happy to update that as well with or without this change.

I also didn't see an existing test for `loadNpmTasks` and wasn't sure how to add one (since it would depend on another module being present). I'd appreciate any guidance there, too!
