### PR TITLE
Add destpath to process callback (Ref #1161)

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -318,7 +318,7 @@ file.copy = function(srcpath, destpath, options) {
   if (process) {
     grunt.verbose.write('Processing source...');
     try {
-      contents = options.process(contents, srcpath);
+      contents = options.process(contents, srcpath, destpath);
       grunt.verbose.ok();
     } catch(e) {
       grunt.verbose.error();

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -513,12 +513,12 @@ exports['file'] = {
     test.done();
   },
   'copy and process': function(test) {
-    test.expect(13);
+    test.expect(14);
     var tmpfile;
     tmpfile = new Tempfile();
     grunt.file.copy('test/fixtures/utf8.txt', tmpfile.path, {
-      process: function(src, filepath) {
-        test.equal(filepath, 'test/fixtures/utf8.txt', 'filepath should be passed in, as-specified.');
+      process: function(src, srcpath) {
+        test.equal(srcpath, 'test/fixtures/utf8.txt', 'srcpath should be passed in, as-specified.');
         test.equal(Buffer.isBuffer(src), false, 'when no encoding is specified, use default encoding and process src as a string');
         test.equal(typeof src, 'string', 'when no encoding is specified, use default encoding and process src as a string');
         return 'føø' + src + 'bår';
@@ -560,6 +560,15 @@ exports['file'] = {
       }
     });
     test.equal(grunt.file.read(tmpfile.path), 'føø' + this.string + 'bår', 'file should be saved as properly encoded processed string.');
+    tmpfile.unlinkSync();
+
+    tmpfile = new Tempfile();
+    grunt.file.copy('test/fixtures/a.js', tmpfile.path, {
+      process: function(src, srcpath, destpath) {
+        test.equal(destpath, tmpfile.path, 'pass destination path to process');
+        return 'foobar';
+      }
+    });
     tmpfile.unlinkSync();
 
     var filepath = path.join(tmpdir.path, 'should-not-exist.txt');


### PR DESCRIPTION
Change for issue #1161. There doesn't seem to be any reason not to pass the destination path to the process callback, since it is already available and it could definitely be useful in some cases. This change adds that. It isn't a breaking change, any gruntfiles and process callbacks not referencing the third argument will ignore it and work as usual.

Also see docs issue https://github.com/gruntjs/grunt-docs/issues/79 and PR https://github.com/gruntjs/grunt-docs/pull/80.
