### PR TITLE
Option "default" has been added to file.readJSON.

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -250,16 +250,25 @@ file.read = function(filepath, options) {
 
 // Read a file, parse its contents, return an object.
 file.readJSON = function(filepath, options) {
-  var src = file.read(filepath, options);
-  var result;
-  grunt.verbose.write('Parsing ' + filepath + '...');
+  if (!options) { options = {}; }
   try {
-    result = JSON.parse(src);
-    grunt.verbose.ok();
-    return result;
+    var src = file.read(filepath, options);
+    var result;
+    grunt.verbose.write('Parsing ' + filepath + '...');
+    try {
+      result = JSON.parse(src);
+      grunt.verbose.ok();
+      return result;
+    } catch (e) {
+      grunt.verbose.error();
+      throw grunt.util.error('Unable to parse "' + filepath + '" file (' + e.message + ').', e);
+    }
   } catch(e) {
-    grunt.verbose.error();
-    throw grunt.util.error('Unable to parse "' + filepath + '" file (' + e.message + ').', e);
+    if (options.default) {
+      return options.default;
+    } else {
+      throw e;
+    }
   }
 };
 

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -429,7 +429,7 @@ exports['file'] = {
     test.done();
   },
   'readJSON': function(test) {
-    test.expect(3);
+    test.expect(8);
     var obj;
     obj = grunt.file.readJSON('test/fixtures/utf8.json');
     test.deepEqual(obj, this.object, 'file should be read as utf8 by default and parsed correctly.');
@@ -440,6 +440,23 @@ exports['file'] = {
     grunt.file.defaultEncoding = 'iso-8859-1';
     obj = grunt.file.readJSON('test/fixtures/iso-8859-1.json');
     test.deepEqual(obj, this.object, 'changing the default encoding should work.');
+
+    test.throws(function() {
+      obj = grunt.file.readJSON('test/fixtures/nonexistent.json');
+    }, 'Attempting to get nonexistent file should throw an exception.');
+
+    var default_obj = {'string': 'test', 'arr': ['item1', 'item2'], 'int': 1};
+    test.doesNotThrow(function() {
+      obj = grunt.file.readJSON('test/fixtures/nonexistent.json', {'default': default_obj});
+    }, 'Attempting to get nonexistent file with "default" option should not throw an exception.');
+
+    test.deepEqual(obj, default_obj, 'default value should be returned if file not exists.');
+
+    test.doesNotThrow(function() {
+      obj = grunt.file.readJSON('test/fixtures/empty.json', {'default': default_obj});
+    }, 'Attempting to get empty file with "default" option should not throw an exception.');
+    test.deepEqual(obj, default_obj, 'default value should be returned if file is empty.');
+
     test.done();
   },
   'readYAML': function(test) {


### PR DESCRIPTION
Before it, in case when file is not exists or empty some Exception raised.
But now, if option "default" passed (only if passed) it returned if file not exists or empty instead exception.

Useful case:
We try to override some options from json file that can not exists. And now we are writing construction:
overwrite: grunt.file.exists('app_dev/manifest.json') ? grunt.file.readJSON('app_dev/manifest.json') : {}

But with new option "default" it will be like:
overwrite: grunt.file.readJSON('app_dev/manifest.json', {default:{}})