### PR TITLE
Set the done flag on the context so it can be determined if complete was called

### DIFF
--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -211,6 +211,8 @@
         // The task succeeded.
         success = true;
       }
+      // Set the done flag on the context so it can be determined if complete was called
+      context.done = true;
       // The task has ended, reset the current task object.
       this.current = {};
       // A task has "failed" only if it returns false (async) or if the


### PR DESCRIPTION
This is needed because `grunt-contrib-watch` calls `complete` on our behalf. We should not call `done` ourself in this case. This change will allow us to check for external completion inside our task.

More : https://github.com/gruntjs/grunt-contrib-watch/issues/361#issuecomment-50856553
