### PR TITLE
Update most dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,22 +44,22 @@
     "tool"
   ],
   "dependencies": {
-    "async": "~0.1.22",
-    "coffee-script": "~1.3.3",
+    "async": "~0.9.0",
+    "coffee-script": "~1.7.1",
     "colors": "~0.6.2",
-    "dateformat": "1.0.2-1.2.3",
+    "dateformat": "1.0.8-1.2.3",
     "eventemitter2": "~0.4.13",
     "findup-sync": "~0.1.2",
-    "glob": "~3.1.21",
+    "glob": "~4.0.5",
     "hooker": "~0.2.3",
-    "iconv-lite": "~0.2.11",
-    "minimatch": "~0.2.12",
-    "nopt": "~1.0.10",
+    "iconv-lite": "~0.4.4",
+    "minimatch": "~1.0.0",
+    "nopt": "~3.0.1",
     "rimraf": "~2.2.8",
     "lodash": "~0.9.2",
-    "underscore.string": "~2.2.1",
+    "underscore.string": "~2.3.3",
     "which": "~1.0.5",
-    "js-yaml": "~2.0.5",
+    "js-yaml": "~3.1.0",
     "exit": "~0.1.1",
     "getobject": "~0.1.0",
     "grunt-legacy-util": "~0.2.0",
@@ -67,11 +67,11 @@
   },
   "devDependencies": {
     "temporary": "~0.0.4",
-    "grunt-contrib-jshint": "~0.6.4",
-    "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt-contrib-watch": "~0.6.1",
     "difflet": "~0.2.3",
-    "semver": "2.1.0",
-    "shelljs": "~0.2.5"
+    "semver": "3.0.1",
+    "shelljs": "~0.3.0"
   }
 }


### PR DESCRIPTION
Updated most dependencies, using the listing from `npm outdated`. Tests still run, so I guess it works.

I also updated lodash, but that broke the tests. Leaving it out for now. (Current is 0.9.2, latest is 2.4.1)

grunt-legacy-util should update its async (0.9.0), underscore.string (2.3.3) and lodash packages.

Also fixes #1183.
