### PR TITLE
Add missing filtering of task `src` files

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -161,6 +161,11 @@ task.normalizeMultiTaskFiles = function(data, target) {
       });
     }
 
+    // Apply filter function
+    if (data.filter) {
+      obj.src = obj.src.filter(data.filter);
+    }
+
     // Copy obj properties to result, adding an .orig property.
     var result = grunt.util._.extend({}, obj);
     // Make a clone of the orig obj available.

--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -104,7 +104,7 @@ task.normalizeMultiTaskFiles = function(data, target) {
       files.push(obj);
     } else if (grunt.util.kindOf(data.files) === 'object') {
       for (prop in data.files) {
-        files.push({src: data.files[prop], dest: grunt.config.process(prop)});
+        files.push({src: data.files[prop], dest: grunt.config.process(prop), filter: data.filter});
       }
     } else if (Array.isArray(data.files)) {
       grunt.util._.flatten(data.files).forEach(function(obj) {
@@ -113,7 +113,7 @@ task.normalizeMultiTaskFiles = function(data, target) {
           files.push(obj);
         } else {
           for (prop in obj) {
-            files.push({src: obj[prop], dest: grunt.config.process(prop)});
+            files.push({src: obj[prop], dest: grunt.config.process(prop), filter: data.filter});
           }
         }
       });
@@ -161,15 +161,16 @@ task.normalizeMultiTaskFiles = function(data, target) {
       });
     }
 
-    // Apply filter function
-    if (data.filter) {
-      obj.src = obj.src.filter(data.filter);
+    if (!obj.filter) {
+      delete obj.filter;
     }
 
     // Copy obj properties to result, adding an .orig property.
     var result = grunt.util._.extend({}, obj);
     // Make a clone of the orig obj available.
     result.orig = grunt.util._.extend({}, obj);
+
+    delete result.filter;
 
     if ('src' in result) {
       // Expose an expand-on-demand getter method as .src.

--- a/test/grunt/task_test.js
+++ b/test/grunt/task_test.js
@@ -145,6 +145,69 @@ exports['task.normalizeMultiTaskFiles'] = {
 
     test.done();
   },
+  'filter': function(test) {
+    test.expect(3);
+    var actual, expected, value;
+
+    var filter = function(file) {
+      return (/\/file[0-9]\.js$/).test(file);
+    };
+
+    value = {
+      dest: 'dest/file1.js',
+      src: [
+        'src/file1.js',
+        'src/file1-123.js'
+      ],
+      filter: filter
+    };
+    actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
+    expected = [
+      {
+        dest: 'dest/file1.js', src: ['src/file1.js'], orig: value
+      }
+    ];
+    test.deepEqual(actual, expected, 'should filter plain src arrays.');
+
+    value = {
+      files: {
+        'dest/file1.js': ['src/file1.js', 'src/file1-123.js'],
+        'dest/file2.js': ['src/file2.js', 'src/file2-123.js']
+      },
+      filter: filter
+    };
+    actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
+    expected = [
+      {
+        dest: 'dest/file1.js', src: ['src/file1.js'], orig: {
+          dest: 'dest/file1.js', src: value.files['dest/file1.js'],
+          filter: value.filter
+        }
+      },
+      {
+        dest: 'dest/file2.js', src: ['src/file2.js'], orig: {
+          dest: 'dest/file2.js', src: value.files['dest/file2.js'],
+          filter: value.filter
+        }
+      }
+    ];
+    test.deepEqual(actual, expected, 'should filter file objects.');
+
+    value = {
+      files: [
+        { dest: 'dest/file1.js', src: ['src/file1.js', 'src/file1-123.js'], filter: filter },
+        { dest: 'dest/file2.js', src: ['src/file2.js', 'src/file2-123.js'], filter: filter }
+      ]
+    };
+    actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
+    expected = [
+      { dest: 'dest/file1.js', src: ['src/file1.js'], orig: value.files[0] },
+      { dest: 'dest/file2.js', src: ['src/file2.js'], orig: value.files[1] }
+    ];
+    test.deepEqual(actual, expected, 'should filter file arrays.');
+
+    test.done();
+  },
   'nonull': function(test) {
     test.expect(2);
     var actual, expected, value;


### PR DESCRIPTION
The documentation [mentions](http://gruntjs.com/configuring-tasks#custom-filter-function) that one can filter the source files with a custom filter function. After some failed attempts at using that feature I had a look at the source and noticed the filter feature works only in some cases (compact & files array).

I've added some tests for the filter-thing and made it work for the following file configurations:

``` js
// Compact (http://gruntjs.com/configuring-tasks#compact-format)
target1: {
  dest: 'dist/file1.js',
  src: [ 'one/**/*.js' ],
  filter: filterFn
},
// Files object (http://gruntjs.com/configuring-tasks#files-object-format)
target2: {
  files: {
    'dist/file1.js': [ 'one/**/*.js' ],
    'dist/file2.js': [ 'two/**/*.js' ]
  },
  filter: filterFn
},
// Files array (http://gruntjs.com/configuring-tasks#files-array-format)
target3: {
  files: [
    { dest: 'dist/file1.js', src: [ 'one/**/*.js' ], filter: filterFn },
    { dest: 'dist/file2.js', src: [ 'two/**/*.js' ], filter: filterFn }
  ]
},
// Files objects in array (undocumented?)
target4: {
  files: [
    { 'dist/file1.js': [ 'one/**/*.js' ] },
    { 'dist/file2.js': [ 'two/**/*.js' ] }
  ],
  filter: filterFn
},
```

Note that the resulting files object does not contain the `filter` property (but `.orig` does).
