### PR TITLE
(experimental) Support grunt-contrib-watch style files: srcArray

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -94,10 +94,11 @@ task.normalizeMultiTaskFiles = function(data, target) {
   var prop, obj;
   var files = [];
   if (grunt.util.kindOf(data) === 'object') {
-    if ('src' in data || 'dest' in data) {
-      obj = {};
+    if ('src' in data || 'dest' in data ||
+       ('files' in data && grunt.util.kindOf(data.files[0]) === 'string')) {
+      obj = ('files' in data) ? { src: data.files } : {};
       for (prop in data) {
-        if (prop !== 'options') {
+        if (prop !== 'options' && prop !== 'files') {
           obj[prop] = data[prop];
         }
       }

--- a/test/grunt/task_test.js
+++ b/test/grunt/task_test.js
@@ -13,7 +13,7 @@ exports['task.normalizeMultiTaskFiles'] = {
     done();
   },
   'normalize': function(test) {
-    test.expect(7);
+    test.expect(8);
     var actual, expected, key, value;
     var flatten = grunt.util._.flatten;
 
@@ -117,6 +117,18 @@ exports['task.normalizeMultiTaskFiles'] = {
       },
     ];
     test.deepEqual(actual, expected, 'should normalize target: {files: [{src: srcStuff, dest: destStuff}, ...]}.');
+
+    value = {
+      files: ['src/*2.js', 'src/*1.js']
+    };
+    actual = grunt.task.normalizeMultiTaskFiles(value, 'ignored');
+    expected = [
+      {
+        src: ['src/file2.js', 'src/file1.js'],
+        orig: { src: value.files }
+      }
+    ];
+    test.deepEqual(actual, expected, 'should normalize target: {files: srcArray}.');
 
     value = {
       files: [


### PR DESCRIPTION
I'm not sure if this breaks some tasks, but couldn't Grunt support the `grunt-contrib-watch` style of specifying files? When I started using Grunt I found it pretty confusing to have this one "blessed" watch plugin that is used everywhere but that is configured differently from every other plugin.

Do you think the benefits outweigh the downside of having to support yet another way of specifying files? (TBH it's just treating `files` like `src` in case `files` contains strings)

Ex: increasing levels of detail/verbosity in `target.files`
```js
// new / grunt-contrib-watch style
target1: {
  files: ['**/*.js']
},
// files object
target2: {
  files: { 'dist/file.js': ['**/*.js'] }
},
// files objects in array
target3: {
  files: [
    { 'dist/file-a.js': ['a/**/*.js'] },
    { 'dist/file-b.js': ['b/**/*.js'] }
  ]
},
// files array
target4: {
  files: [
    { src: 'dist/file-a.js', dest: ['a/**/*.js'], /* ... */ },
    { src: 'dist/file-b.js', dest: ['b/**/*.js'], /* ... */ }
  ]
}
```