### PR TITLE
Test on both x86 and x64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,10 @@ matrix:
   allow_failures:
     - nodejs_version: "0.11"
 
+platform:
+  - x86
+  - x64
+
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node 0.STABLE.latest


### PR DESCRIPTION
... for Windows (AppVeyor). I'm not quite sure how to do the same for Linux (Travis), but I think it's like this:

```
matrix:
  include:
    - os: linux
      env: TARGET=linux ARCH=x86_64
    - os: linux
      env: TARGET=linux ARCH=i686
```

Corrections?
