### PR TITLE
Add test-ci npm script that outputs tests results in a separate file.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,14 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     nodeunit: {
-      all: ['test/{grunt,tasks,util}/**/*.js']
+      all: ['test/{grunt,tasks,util}/**/*.js'],
+      tap: {
+        src: '<%= nodeunit.all %>',
+        options: {
+          reporter: 'tap',
+          reporterOutput: 'tests.tap'
+        }
+      }
     },
     jshint: {
       gruntfile_tasks: ['Gruntfile.js', 'internal-tasks/*.js'],
@@ -63,7 +70,9 @@ module.exports = function(grunt) {
   grunt.loadTasks('internal-tasks');
 
   // "npm test" runs these tasks
-  grunt.registerTask('test', ['jshint', 'nodeunit', 'subgrunt']);
+  grunt.registerTask('test', '', function(reporter) {
+    grunt.task.run(['jshint', 'nodeunit:' + (reporter || 'all'), 'subgrunt']);
+  });
 
   // Default task.
   grunt.registerTask('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "main": "lib/grunt",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "test-tap": "grunt test:tap"
   },
   "engines": {
     "node": ">= 0.8.0"
@@ -68,7 +69,7 @@
   "devDependencies": {
     "temporary": "~0.0.4",
     "grunt-contrib-jshint": "~0.6.4",
-    "grunt-contrib-nodeunit": "~0.2.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
     "difflet": "~0.2.3",
     "semver": "2.1.0",


### PR DESCRIPTION
I'm currently working on setting up a Jenkins job that tests grunt against Node.js' v0.12 branch (which contains the code for the upcoming 0.12 stable version). While doing so, I wanted to be able to run all tests (the equivalent of `npm test`) and parse the results so that I could examine tests failures easily.

Currently, the tests results are outputted to standard error or output using the default reporter, and it makes parsing tests results difficult.

Having a separate npm script like `test-ci` that outputs tests results to files with a standard format that is easy to parse by a program (TAP) is very helpful.

This change also adds `grunt-cli` as a local dependency, so that we don't have to manage this dependency at the system level where the continuous integration tools are installed. I don't think this specific change should be done within this PR, but since this PR is about making testing grunt easier on a CI platform, I thought I would keep it here for now until I gather more feedback from you.

Finally, it upgrades `grunt-contrib-nodeunit` to a version that supports the `reporterOutput` option.

Please let me know what you think.