### PR TITLE
Allow async tasks to preserve original setTimeout

### DIFF
--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -11,6 +11,8 @@
 
   'use strict';
 
+  var origSetTimeout = setTimeout;
+
   // Construct-o-rama.
   function Task() {
     // Information about the currently-running task.
@@ -238,7 +240,7 @@
       // The returned function should execute asynchronously in case
       // someone tries to do this.async()(); inside a task (WTF).
       return function(success) {
-        setTimeout(function() { complete(success); }, 1);
+        origSetTimeout(function() { complete(success); }, 1);
       };
     };
 

--- a/test/util/task_test.js
+++ b/test/util/task_test.js
@@ -169,6 +169,43 @@ exports['Tasks'] = {
     });
     task.run('syncs', 'asyncs').start();
   },
+  'Task#run (async with fake setTimeout)': function(test) {
+    test.expect(1);
+    var task = this.task;
+    var results = [];
+
+    task.registerTask('fake_timer', 'async, with fake setTimeout', function() {
+      var done;
+      var origSetTimeout = setTimeout;
+      /* global setTimeout:true */
+      setTimeout = false;
+      /* global setTimeout:false */
+
+      done = this.async();
+
+      origSetTimeout(function() {
+        results.push( 'async' );
+        done();
+      }, 1);
+
+      /* global setTimeout:true */
+      setTimeout = origSetTimeout;
+      /* global setTimeout:false */
+    });
+
+    task.options({
+      error: function(e) {
+        results.push({name: e.name, message: e.message});
+      },
+      done: function() {
+        test.deepEqual(results, [
+          'async'
+        ], 'The specified task should have run, even with a fake setTimeout.');
+        test.done();
+      }
+    });
+    task.run('fake_timer').start();
+  },
   'Task#exists': function(test) {
     test.expect(2);
     var task = this.task;


### PR DESCRIPTION
With these changes, we can preserve the setTimeout function used
internally on  on the registerTask context.

Without this patch, any task replacing setTimeout might break grunt
in order to not trigger the task.done event.
