### PR TITLE
Search ancestors for node_modules in grunt.loadNpmTasks

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -381,7 +381,7 @@ task.loadTasks = function(tasksdir) {
 // relative to the base dir).
 task.loadNpmTasks = function(name) {
   loadTasksMessage('"' + name + '" local Npm module');
-  var root = path.resolve('node_modules');
+  var root = grunt.file.findup('node_modules');
   var pkgfile = path.join(root, name, 'package.json');
   var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
 


### PR DESCRIPTION
Fixes #1211.

**_Note**_: the reporter of the issue suggested using `require`. I initially tried using that to implement this. However, I soon ran into issues, and I realized that there is a fundamental issue: a module can only be `require`d if it specifies a `main` file in its `package.json` ([docs reference](http://nodejs.org/api/modules.html#modules_folders_as_modules)). Many Grunt plugins do not do this--so that approach is out.
