### PR TITLE
Faster way to switch node.js version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ matrix:
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node 0.STABLE.latest
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+  - ps: Install-Product node $env:nodejs_version
   # Typical npm stuff.
   - npm install
   # Grunt-specific stuff.


### PR DESCRIPTION
There is a new script in AppVeyor environment that allows switching Node.js version/platform almost instantly.
