### PR TITLE
Ignore functions within patterns

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -51,6 +51,10 @@ var processPatterns = function(patterns, fn) {
   var result = [];
   // Iterate over flattened patterns array.
   grunt.util._.flatten(patterns).forEach(function(pattern) {
+    // If the pattern is a function, ignore it
+    if (typeof pattern === 'function') {
+      return;
+    }
     // If the first character is ! it should be omitted
     var exclusion = pattern.indexOf('!') === 0;
     // If the pattern is an exclusion, remove the !

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -232,6 +232,11 @@ exports['file.expand*'] = {
     test.deepEqual(grunt.file.expand(opts, ['js/foo.js', 'js/bar.js', 'js/baz.js']), ['js/foo.js', 'js/bar.js', 'js/baz.js'], 'non-matching filenames should be returned in result set.');
     test.done();
   },
+  'ignore functions within patterns': function(test) {
+    test.expect(1);
+    test.deepEqual(grunt.file.expand(['**/*.js', function() {}]), ['js/bar.js', 'js/foo.js'], 'functions passed in with patterns should be ignored.');
+    test.done();
+  },
 };
 
 exports['file.expandMapping'] = {


### PR DESCRIPTION
If you have a task that is configured to read targets as functions, it works fine. But when `verbose` is enabled, the function gets treated as a src array here: https://github.com/shama/grunt/blob/master/lib/grunt/task.js#L199

and produces the error:

``` shell
TypeError: Object function () {
      } has no method 'indexOf'
    at /Users/Kyle/Documents/www/grunt-gulp/node_modules/grunt/lib/grunt/file.js:55:29
    at Array.forEach (native)
    at processPatterns (/Users/Kyle/Documents/www/grunt-gulp/node_modules/grunt/lib/grunt/file.js:53:34)
    at Object.file.expand (/Users/Kyle/Documents/www/grunt-gulp/node_modules/grunt/lib/grunt/file.js:110:17)
    at Object.fn [as src] (/Users/Kyle/Documents/www/grunt-gulp/node_modules/grunt/lib/grunt/task.js:180:36)
    at /Users/Kyle/Documents/www/grunt-gulp/node_modules/grunt/lib/grunt/task.js:199:24
    at Array.forEach (native)
    at Task.task.normalizeMultiTaskFiles (/Users/Kyle/Documents/www/grunt-gulp/node_modules/grunt/lib/grunt/task.js:196:11)
```

This PR just ignores any pattern that is a `function` as I think that is the most robust way to avoid hitting this hard error. Thanks!

Ref shama/grunt-gulp#1
