### PR TITLE
Search upwards if the tasks directory isn't found locally.

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -380,7 +380,14 @@ task.loadTasks = function(tasksdir) {
 task.loadNpmTasks = function(name) {
   loadTasksMessage('"' + name + '" local Npm module');
   var root = path.resolve('node_modules');
-  var pkgfile = path.join(root, name, 'package.json');
+  var pkgdir = path.join(root, name);
+
+  // If the package directory is not found, try to find upwards
+  if(!grunt.file.exists(pkgdir)) {
+    pkgdir = grunt.file.findup('node_modules/' + name);
+  }
+
+  var pkgfile = path.join(pkgdir, 'package.json');
   var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
 
   // Process collection plugins.
@@ -403,7 +410,7 @@ task.loadNpmTasks = function(name) {
   }
 
   // Process task plugins.
-  var tasksdir = path.join(root, name, 'tasks');
+  var tasksdir = path.join(pkgdir, 'tasks');
   if (grunt.file.exists(tasksdir)) {
     loadTasks(tasksdir);
   } else {


### PR DESCRIPTION
Fixes #1211.

It actually fix some cases that aren't handled by #1229.