### PR TITLE
grunt.file.mkdir: Don't throw error when dir was created by another process

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -199,6 +199,11 @@ file.mkdir = function(dirpath, mode) {
       try {
         fs.mkdirSync(subpath, mode);
       } catch(e) {
+        if(e.code === 'EEXIST' && file.isDir(subpath)) {
+          // The path was created between exists() and mkdirSync().
+          // If it's a directory, we're done.
+          return parts;
+        }
         throw grunt.util.error('Unable to create directory "' + subpath + '" (Error code: ' + e.code + ').', e);
       }
     }


### PR DESCRIPTION
When using grunt-concurrent, multiple tasks can attempt to create the same directory. This caused EEXIST errors coming from grunt.file.mkdir. This patch should fix that.
