### PR TITLE
--verbose implies --stack

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -41,7 +41,7 @@ function writeln(e, mode) {
 
 // If --stack is enabled, log the appropriate error stack (if it exists).
 function dumpStack(e) {
-  if (grunt.option('stack')) {
+  if (grunt.option('stack') || grunt.option('verbose')) {
     if (e.origError && e.origError.stack) {
       console.log(e.origError.stack);
     } else if (e.stack) {


### PR DESCRIPTION
If grunt is invoked with `--verbose`, we should also print stack traces, since the user was most likely invoking `--verbose` to debug their failing grunt task