### PR TITLE
allow the specification of a callback in Task#run

### DIFF
--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -171,6 +171,11 @@
 
   // Enqueue a task.
   Task.prototype.run = function() {
+    // pull out a callback then parse arguments as normal
+    if (typeof(arguments[arguments.length - 1]) === 'function') {
+      this._options.done = arguments[arguments.length - 1];
+      delete arguments[arguments.length - 1];
+    }
     // Parse arguments into an array, returning an array of task+args objects.
     var things = this.parseArgs(arguments).map(this._taskPlusArgs, this);
     // Throw an exception if any tasks weren't found.

--- a/test/util/task_test.js
+++ b/test/util/task_test.js
@@ -278,6 +278,17 @@ exports['Tasks'] = {
     });
     task.run('a', 'h').start();
   },
+  'Task#run (callback)': function(test) {
+    test.expect(2);
+    var task  = this.task;
+    task.registerTask('a', 'Push task name onto result and run other tasks', function() { result.push(this.name); task.run('b'); delay(this.async()); });
+    task.registerTask('b', 'Push task onto result', result.pushTaskname);
+    task.run('a', function() {
+      test.strictEqual(result.getJoined(), 'ab', 'Tasks should run in order');
+      test.strictEqual(true, true, 'this call back should be run when the task is finished');
+      test.done();
+    }).start();
+  },
   'Task#current': function(test) {
     test.expect(8);
     var task = this.task;


### PR DESCRIPTION
An attempt at https://github.com/gruntjs/grunt/issues/1184, really it just pulls out a callback from the run function and uses it for done(). The issue is old and I didn't see an official response so I thought I would take a stab at it.