### PR TITLE
Fix issue where grunt.file.isLink() returned false for relative links

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -403,7 +403,15 @@ file.exists = function() {
 // True if the file is a symbolic link.
 file.isLink = function() {
   var filepath = path.join.apply(path, arguments);
-  return file.exists(filepath) && fs.lstatSync(filepath).isSymbolicLink();
+  try {
+    return fs.lstatSync(filepath).isSymbolicLink();
+  } catch(e) {
+    if (e.code === 'ENOENT') {
+      // The file doesn't exist, so it's not a symbolic link.
+      return false;
+    }
+    throw grunt.util.error('Unable to read "' + filepath + '" file (Error code: ' + e.code + ').', e);
+  }
 };
 
 // True if the path is a directory.

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -755,11 +755,16 @@ exports['file'] = {
     test.done();
   },
   'isLink': function(test) {
-    test.expect(6);
+    test.expect(8);
     test.equals(grunt.file.isLink('test/fixtures/octocat.png'), false, 'files are not links.');
     test.equals(grunt.file.isLink('test/fixtures'), false, 'directories are not links.');
     test.ok(grunt.file.isLink(path.join(tmpdir.path, 'octocat.png')), 'file links are links.');
     test.ok(grunt.file.isLink(path.join(tmpdir.path, 'expand')), 'directory links are links.');
+    grunt.file.mkdir(path.join(tmpdir.path, 'relative-links'));
+    fs.symlinkSync('test/fixtures/octocat.png', path.join(tmpdir.path, 'relative-links/octocat.png'), 'file');
+    fs.symlinkSync('test/fixtures/expand', path.join(tmpdir.path, 'relative-links/expand'), 'file');
+    test.ok(grunt.file.isLink(path.join(tmpdir.path, 'relative-links/octocat.png')), 'relative file links are links.');
+    test.ok(grunt.file.isLink(path.join(tmpdir.path, 'relative-links/expand')), 'relative directory links are links.');
     test.ok(grunt.file.isLink(tmpdir.path, 'octocat.png'), 'should work for paths in parts.');
     test.equals(grunt.file.isLink('test/fixtures/does/not/exist'), false, 'nonexistent files are not links.');
     test.done();


### PR DESCRIPTION
Ran into an issue where some symlinks weren't being reported as such when tested via `grunt.file.isLink`. 

Turns out relative symlinks show up as nonexistent to Node's `fs.exists`, but they are actually recognized correctly via `fs.lstatSync`.

I've removed the `file.exists` check in `grunt.file.isLink` so that relative links work, and then am handling nonexistent files within the `catch`.

Added tests, and confirmed that they all pass on OS X Yosemite, Ubuntu 14.04, and Windows 7, and were failing [before the fixes were made](https://github.com/greglittlefield-wf/grunt/compare/recognize-relative-links-failing).
