### PR TITLE
Update license year

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2014 "Cowboy" Ben Alman
+Copyright (c) 2015 "Cowboy" Ben Alman
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
Update license year for 2015. No other changes were made.
![grunt license update](https://cloud.githubusercontent.com/assets/8637335/6101040/ac6c9bb6-afd1-11e4-84e2-592a1ea308f5.png)