### PR TITLE
package.json: use http git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "http://gruntjs.com/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/gruntjs/grunt.git"
+    "url": "https://github.com/gruntjs/grunt.git"
   },
   "bugs": {
     "url": "http://github.com/gruntjs/grunt/issues"


### PR DESCRIPTION
git protocol is a pain in many environments, http is the proxy friendly alternative