### PR TITLE
Add fallback option for readJSON

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -258,6 +258,14 @@ file.readJSON = function(filepath, options) {
     return result;
   } catch (e) {
     if (options.fallback) {
+      if (e.code === 'ENOENT') {
+        grunt.verbose.write('File ' + filepath + ' was not found. Reverting to fallback value.');
+        grunt.verbose.write(options.fallback);
+      } else if (e instanceof SyntaxError) {
+        grunt.verbose.write('File ' + filepath + ' is malformed (check for syntax errors). Reverting to fallback value.');
+        grunt.verbose.write(options.fallback);
+      }
+      grunt.verbose.ok();
       return options.fallback;
     }
     grunt.verbose.error();

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -243,9 +243,6 @@ file.read = function(filepath, options) {
     grunt.verbose.ok();
     return contents;
   } catch (e) {
-    if (options.fallback) {
-      return JSON.stringify(options.fallback);
-    }
     grunt.verbose.error();
     throw grunt.util.error('Unable to read "' + filepath + '" file (Error code: ' + e.code + ').', e);
   }
@@ -253,14 +250,16 @@ file.read = function(filepath, options) {
 
 // Read a file, parse its contents, return an object.
 file.readJSON = function(filepath, options) {
-  var src = file.read(filepath, options);
-  var result;
   grunt.verbose.write('Parsing ' + filepath + '...');
   try {
-    result = JSON.parse(src);
+    var src = file.read(filepath, options);
+    var result = JSON.parse(src);
     grunt.verbose.ok();
     return result;
   } catch (e) {
+    if (options.fallback) {
+      return options.fallback;
+    }
     grunt.verbose.error();
     throw grunt.util.error('Unable to parse "' + filepath + '" file (' + e.message + ').', e);
   }

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -243,6 +243,9 @@ file.read = function(filepath, options) {
     grunt.verbose.ok();
     return contents;
   } catch (e) {
+    if (options.fallback) {
+      return JSON.stringify(options.fallback);
+    }
     grunt.verbose.error();
     throw grunt.util.error('Unable to read "' + filepath + '" file (Error code: ' + e.code + ').', e);
   }

--- a/test/fixtures/malformed.json
+++ b/test/fixtures/malformed.json
@@ -1,0 +1,4 @@
+{
+  "key": "value"
+  "secondKey": "value"
+}

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -428,13 +428,16 @@ exports['file'] = {
     test.done();
   },
   'readJSON': function(test) {
-    test.expect(3);
+    test.expect(4);
     var obj;
     obj = grunt.file.readJSON('test/fixtures/utf8.json');
     test.deepEqual(obj, this.object, 'file should be read as utf8 by default and parsed correctly.');
 
     obj = grunt.file.readJSON('test/fixtures/iso-8859-1.json', {encoding: 'iso-8859-1'});
     test.deepEqual(obj, this.object, 'file should be read using the specified encoding.');
+
+    obj = grunt.file.readJSON('missing-file.json', {fallback: {}});
+    test.deepEqual(obj, {}, 'providing a fallback object should be returned if the JSON file is not found.');
 
     grunt.file.defaultEncoding = 'iso-8859-1';
     obj = grunt.file.readJSON('test/fixtures/iso-8859-1.json');

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -428,7 +428,7 @@ exports['file'] = {
     test.done();
   },
   'readJSON': function(test) {
-    test.expect(4);
+    test.expect(5);
     var obj;
     obj = grunt.file.readJSON('test/fixtures/utf8.json');
     test.deepEqual(obj, this.object, 'file should be read as utf8 by default and parsed correctly.');
@@ -438,6 +438,9 @@ exports['file'] = {
 
     obj = grunt.file.readJSON('missing-file.json', {fallback: {}});
     test.deepEqual(obj, {}, 'providing a fallback object should be returned if the JSON file is not found.');
+
+    obj = grunt.file.readJSON('test/fixtures/malformed.json', {fallback: {key: 'value'}});
+    test.deepEqual(obj, {key: 'value'}, 'providing a fallback object should be returned if the JSON file is malformed.');
 
     grunt.file.defaultEncoding = 'iso-8859-1';
     obj = grunt.file.readJSON('test/fixtures/iso-8859-1.json');


### PR DESCRIPTION
Resolves #1324.

This should handle missing and malformed JSON files, so that users can pass a fallback object that they would like to be returned. 

This is my first time writing nodeunit tests so I'm not really sure why I couldn't use `this.object` in my `deepEqual` assertions. If someone could point me in the right direction (assuming it's a requirement) regarding that, along with any more feedback / suggestions for more tests, it is welcomed and appreciated!

I also realized this feature could go up a level to `file.read`, but, to keep a limited scope to what I know JSON can and should return I limited it to `readJSON`. 