### PR TITLE
Update coffee script

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -13,7 +13,7 @@
 var path = require('path');
 
 // This allows grunt to require() .coffee files.
-require('coffee-script');
+require('coffee-script/register');
 
 // The module to be exported.
 var grunt = module.exports = {};

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "async": "~0.1.22",
-    "coffee-script": "~1.3.3",
+    "coffee-script": "~1.9.2",
     "colors": "~0.6.2",
     "dateformat": "1.0.2-1.2.3",
     "eventemitter2": "~0.4.13",


### PR DESCRIPTION
There is quite old version 1.3.3 which already has some issues with scripts written in 1.9.2. Unfortunately it has issues other way around too. There are some changes in latest version that can break old code. 

In my opinion the Grunt should not have a coffee-script as a direct dependency. It should just use the version that is installed for a project. Maybe change this to Grunt 0.5 or whatever is next?