### PR TITLE
Added file.contract method

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -131,6 +131,60 @@ file.expand = function() {
   return matches;
 };
 
+// Return an array of simple globbing patterns that match the given array of files.
+file.contract = function() {
+  var args = grunt.util.toArray(arguments);
+  // If the first argument is an options object, save those options.
+  var options = grunt.util.kindOf(args[0]) === 'object' ? args.shift() : {};
+  // Use the first argument if it's an Array, otherwise convert the arguments
+  // object to an array and use that.
+  var files = Array.isArray(args[0]) ? args[0] : args;
+  // Reverse sort the files to get deepest files first.
+  files.sort();
+  files.reverse();
+  var dir = '';
+  var currentDir = '';
+  var children = 0;
+  for (var i = 0; i < files.length; i++) {
+    // Get directory of file.
+    dir = files[i].substr(0, files[i].replace(/\/$/, '').lastIndexOf('/'));
+    // Increase number of known children of directory, to match later
+    if (dir === currentDir) {
+      children ++;
+    // Next directory detected. Time to match know number of children to filesystem.
+    } else {
+      if (currentDir !== '') {
+        // When number of children match, replace the children for the directory and start over.
+        if (fs.readdirSync(path.join(options.cwd || '', currentDir)).length === children) {
+          files.splice(i - children, children, currentDir + '/');
+          currentDir = '';
+          i = 0;
+          continue;
+        }
+      }
+      // Not yet compared directory, time to reset.
+      currentDir = dir;
+      children = 1;
+    }
+  }
+  // Remove trailing slashes on directories when both globstar and mark are not welcome.
+  if (options.hideglobstar && !options.mark) {
+    Object.keys(files).forEach(function(i) {
+      if (files[i].match(/\/$/)) {
+        files[i] = files[i].replace(/\/$/, '');
+      }
+    });
+  // Default: no hideglobstar will add globstar to all directories.
+  } else if (!options.hideglobstar) {
+    Object.keys(files).forEach(function(i) {
+      if (files[i].match(/\/$/)) {
+        files[i] = files[i] + '**/*';
+      }
+    });
+  }
+  return files.sort();
+};
+
 var pathSeparatorRe = /[\/\\]/g;
 
 // The "ext" option refers to either everything after the first dot (default)

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -234,6 +234,39 @@ exports['file.expand*'] = {
   },
 };
 
+exports['file.contract*'] = {
+  setUp: function(done) {
+    this.cwd = process.cwd();
+    process.chdir('test/fixtures/expand');
+    done();
+  },
+  tearDown: function(done) {
+    process.chdir(this.cwd);
+    done();
+  },
+  'basic matching': function(test) {
+    test.expect(1);
+    test.deepEqual(grunt.file.contract(['css/baz.css', 'deep/deeper/deeper.txt', 'deep/deeper/deepest/deepest.txt', 'js/bar.js', 'js/foo.js']), ['css/baz.css', 'deep/deeper/**/*', 'js/**/*'], 'should match.');
+    test.done();
+  },
+  'options.cwd': function(test) {
+    test.expect(1);
+    var cwd = path.resolve(process.cwd(), '..');
+    test.deepEqual(grunt.file.contract({cwd: cwd}, ['expand/css/baz.css', 'expand/deep/deeper/deeper.txt', 'expand/deep/deeper/deepest/deepest.txt', 'expand/js/bar.js', 'expand/js/foo.js']), ['expand/css/baz.css', 'expand/deep/deeper/**/*', 'expand/js/**/*'], 'should match.');
+    test.done();
+  },
+  'options.hideglobstar': function(test) {
+    test.expect(1);
+    test.deepEqual(grunt.file.contract({hideglobstar: true}, ['css/baz.css', 'deep/deeper/deeper.txt', 'deep/deeper/deepest/deepest.txt', 'js/bar.js', 'js/foo.js']), ['css/baz.css', 'deep/deeper', 'js'], 'should match.');
+    test.done();
+  },
+  'options.mark': function(test) {
+    test.expect(1);
+    test.deepEqual(grunt.file.contract({mark: true, hideglobstar: true}, ['css/baz.css', 'deep/deeper/deeper.txt', 'deep/deeper/deepest/deepest.txt', 'js/bar.js', 'js/foo.js']), ['css/baz.css', 'deep/deeper/', 'js/'], 'should match.');
+    test.done();
+  }
+};
+
 exports['file.expandMapping'] = {
   setUp: function(done) {
     this.cwd = process.cwd();


### PR DESCRIPTION
`file.contract` does the reverse of `file.expand`:
creates simple globbing patterns based on the given array of files,
currently only by detecting directories of which all files are in the given array of files.

Mitigates ENAMETOOLONG error when spawning child processes capable of accepting globs just fine.
For example, trying: `git rm --ignore-unmatch -r -f ['very','long','file','list']` will cause an error, while globs can be used instead.

Usage example:
```js
grunt.file.contract(['css/baz.css', 'deep/deeper/deeper.txt', 'deep/deeper/deepest/deepest.txt', 'js/bar.js', 'js/foo.js']);
/***
 * Output:
 * ['css/baz.css', 'deep/deeper/**/*', 'js/**/*']
 */
```

The tests use the existing `test/fixtures/expand` directory, I hope this is ok.

Can be improved later on by implementing globbing by file extension as well.