### PR TITLE
Stop when declaring an already existing task or a loop

### DIFF
--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -53,6 +53,10 @@
 
   // Register a new task.
   Task.prototype.registerTask = function(name, info, fn) {
+    if (this._tasks[name]) {
+      this._throwIfRunning(new Error('Task "' + name + '" already exists. Please use another name or call grunt.renameTask().'));
+      return this;
+    }
     // If optional "info" string is omitted, shuffle arguments a bit.
     if (fn == null) {
       fn = info;

--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -67,6 +67,11 @@
     if (typeof fn !== 'function') {
       // Array of task names.
       tasks = this.parseArgs([fn]);
+      // if we're defining a loop, throw an exception
+      if (tasks.indexOf(name) > -1) {
+        this._throwIfRunning(new Error('Task "' + name + '" is calling itself. This would cause an infinite loop, please fix.'));
+        return this;
+      }
       // This task function just runs the specified tasks.
       fn = this.run.bind(this, fn);
       fn.alias = true;

--- a/test/util/task_test.js
+++ b/test/util/task_test.js
@@ -59,6 +59,13 @@ exports['Tasks'] = {
     });
     task.run('y', 'z').start();
   },
+  'Task#registerTask (redefinition)': function(test) {
+    test.expect(1);
+    var task = this.task;
+    task.registerTask('nodupe', 'Push task name onto result.', result.pushTaskname);
+    test.throws(function() { task.registerTask('nodupe', result.pushTaskname); }, 'Redefining an existing task should throw an exception');
+    test.done();
+  },
   'Task#isTaskAlias': function(test) {
     test.expect(2);
     var task = this.task;

--- a/test/util/task_test.js
+++ b/test/util/task_test.js
@@ -66,6 +66,12 @@ exports['Tasks'] = {
     test.throws(function() { task.registerTask('nodupe', result.pushTaskname); }, 'Redefining an existing task should throw an exception');
     test.done();
   },
+  'Task#registerTask (loop)': function(test) {
+    test.expect(1);
+    var task = this.task;
+    test.throws(function() { task.registerTask('loop', ['a', 'loop']); }, 'Defining a looping task should throw an exception');
+    test.done();
+  },
   'Task#isTaskAlias': function(test) {
     test.expect(2);
     var task = this.task;


### PR DESCRIPTION
This patch detects 2 error cases:
- registering a task under the name of an already existing one:

```
grunt.loadNpmTasks('grunt-contrib-uglify');
grunt.registerTask('uglify', ['a', 'b']);
```
- registering a looping task:

```
grunt.registerTask('build', ['a', 'build', 'b']);
```

It then throws an exception with an (hopefully useful) error message.

This fixes my issue #1342 and replaces FAQ http://gruntjs.com/frequently-asked-questions#why-am-i-getting-a-maximum-call-stack-size-exceeded-error.
