### PR TITLE
changed success wording

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -79,6 +79,6 @@ fail.report = function() {
   if (fail.warncount > 0) {
     grunt.log.writeln().fail('Done, but with warnings.');
   } else {
-    grunt.log.writeln().success('Done, without errors.');
+    grunt.log.writeln().success('Done.');
   }
 };


### PR DESCRIPTION
Grunt printing 'errors' every time it finishes successfully is very confusing. Mostly if grunt is called within a script. 