### PR TITLE
Update 3 years old coffeescript version

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -13,7 +13,7 @@
 var path = require('path');
 
 // This allows grunt to require() .coffee files.
-require('coffee-script');
+require('coffee-script/register');
 
 // The module to be exported.
 var grunt = module.exports = {};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "async": "~0.1.22",
-    "coffee-script": "~1.3.3",
+    "coffee-script": "~1.9.3",
     "colors": "~0.6.2",
     "dateformat": "1.0.2-1.2.3",
     "eventemitter2": "~0.4.13",


### PR DESCRIPTION
Update version of coffeescript

It updates Coffeescript version from 1.3.3 — MAY 15, 2012 to 1.9.3 — MAY 27, 2015
See http://coffeescript.org/#1.9.3 for details.

https://github.com/gruntjs/grunt/issues/911
https://github.com/gruntjs/grunt/pull/948
https://github.com/gruntjs/grunt/issues/1254
https://github.com/gruntjs/grunt/issues/1266
https://github.com/gruntjs/grunt/pull/1250
And so on...

Probably this is the pull request more times requested.
As I have read it seems that it seems to be frozen until release grunt 0.5.0 (see #911 , 2013 thread)
So you may consider this PR to be a +1 to go ahead
