### PR TITLE
fixes #1391 : set min width size to 0

### DIFF
--- a/lib/grunt/help.js
+++ b/lib/grunt/help.js
@@ -16,12 +16,19 @@ var path = require('path');
 
 // Set column widths.
 var col1len = 0;
+//Set column 1 max width.
+var col1MaxLen = 76;
+
 exports.initCol1 = function(str) {
-  col1len = Math.max(col1len, str.length);
+  var strLength = str.length;
+  if (strLength > col1MaxLen) {
+    throw grunt.util.error('Task name can\'t take more than ' + col1MaxLen + ' characters.');
+  }
+  col1len = Math.max(col1len, strLength);
 };
 exports.initWidths = function() {
   // Widths for options/tasks table output.
-  exports.widths = [1, col1len, 2, 76 - col1len];
+  exports.widths = [1, col1len, 2, Math.max(0, col1MaxLen - col1len)];
 };
 
 // Render an array in table form.

--- a/test/grunt/help_test.js
+++ b/test/grunt/help_test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var help = require('../../lib/grunt/help');
+
+exports.help = {
+  'help.initWidths': function(test) {
+    test.expect(1);
+    help.initCol1('SimpleString');
+    help.initWidths();
+    test.equal(help.widths[3] >= 0, true, 'should always be over or equal to 0');
+    test.done();
+  },
+  'help.initCol1': function(test) {
+    test.expect(2);
+    test.throws(function() { help.initCol1('thisTaskDoesNothingMoreThanTakeALotOfPlaceItsTakeMoreThanOneHundredCharactersItsJustForTheTestAndTestLimitCaseForHelpOption'); }, 'should alert for the task length limit');
+    test.doesNotThrow(function() { help.initCol1('SimpleString'); }, 'should not alert for the task length limit');
+    test.done();
+  },
+};


### PR DESCRIPTION
- Fixes the min widh size to 0 for the tasks column which appear in the help pane.
- Throw an exception if the string take more than 76 characters.
