### PR TITLE
Tests: Warn if symlinks can't be created, but continue tests

### DIFF
--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -11,8 +11,15 @@ var Tempdir = require('temporary/lib/dir');
 var win32 = process.platform === 'win32';
 
 var tmpdir = new Tempdir();
-fs.symlinkSync(path.resolve('test/fixtures/octocat.png'), path.join(tmpdir.path, 'octocat.png'), 'file');
-fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tmpdir.path, 'expand'), 'dir');
+try {
+  fs.symlinkSync(path.resolve('test/fixtures/octocat.png'), path.join(tmpdir.path, 'octocat.png'), 'file');
+  fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tmpdir.path, 'expand'), 'dir');
+} catch (err) {
+  console.error('** ERROR: Cannot create symbolic links; link-related tests will fail.');
+  if (win32) {
+    console.error('** Tests must be run with Administrator privileges on Windows.');
+  }
+}
 
 exports['file.match'] = {
   'empty set': function(test) {


### PR DESCRIPTION
Ref #1442

Windows requires Administrator privileges to create symlinks, give a warning to
that effect but allow tests to complete (and fail).

I thought about putting all the link-related tests into a single unit test but hey, it's gonna fail no matter what and the names of the tests make it pretty clear what happened.