### PR TITLE
Prevent async callback from being called multiple times

### DIFF
--- a/lib/util/task.js
+++ b/lib/util/task.js
@@ -11,6 +11,8 @@
 
   'use strict';
 
+  var grunt = require('../grunt');
+
   // Construct-o-rama.
   function Task() {
     // Information about the currently-running task.
@@ -237,9 +239,9 @@
       async = true;
       // The returned function should execute asynchronously in case
       // someone tries to do this.async()(); inside a task (WTF).
-      return function(success) {
+      return grunt.util._.once(function(success) {
         setTimeout(function() { complete(success); }, 1);
-      };
+      });
     };
 
     // Expose some information about the currently-running task.

--- a/test/util/task_test.js
+++ b/test/util/task_test.js
@@ -278,6 +278,17 @@ exports.Tasks = {
     });
     task.run('a', 'h').start();
   },
+  'Task#run (async task with multiple callbacks)': function(test) {
+    test.expect(1);
+    var task = this.task;
+    task.registerTask('a', 'Call async callback twice.', function() { var done = this.async(); done(); done(); });
+    task.registerTask('b', 'Never call async callback.', function() { this.async(); });
+    task.run('a', 'b').start();
+    delay(function() {
+      test.deepEqual(task.current.name, 'b', 'Should be stuck on task with no async callback');
+      test.done();
+    });
+  },
   'Task#current': function(test) {
     test.expect(8);
     var task = this.task;


### PR DESCRIPTION
* calling the callback multiple times would skip queued task