### PR TITLE
A better way to find local modules

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -405,10 +405,14 @@ task.loadNpmTasks = function(name) {
   }
 
   // Process task plugins.
-  var tasksdir = path.join(root, name, 'tasks');
-  if (grunt.file.exists(tasksdir)) {
-    loadTasks(tasksdir);
-  } else {
+  try {
+    var tasksdir = path.join(require.resolve(name), 'tasks');
+    if (grunt.file.exists(tasksdir)) {
+      loadTasks(tasksdir);
+    } else {
+      throw new Error('Local Npm module not found');
+    }
+  } catch (e) {
     grunt.log.error('Local Npm module "' + name + '" not found. Is it installed?');
   }
 };


### PR DESCRIPTION
NPM3.0+
If a gulpfile is in a npm package, it cant run grunt. Because node_modules is in parent directory. So the require.resolve is a better way to find local modules.