### PR TITLE
Fix broken tests for node 5.7

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -440,8 +440,8 @@ file.doesPathContain = function(ancestor) {
   ancestor = path.resolve(ancestor);
   var relative;
   for (var i = 1; i < arguments.length; i++) {
-    relative = path.relative(path.resolve(arguments[i]), ancestor);
-    if (relative === '' || /\w+/.test(relative)) { return false; }
+    relative = path.relative(ancestor, path.resolve(arguments[i]));
+    if (relative === '' || /^\.\./.test(relative)) { return false; }
   }
   return true;
 };


### PR DESCRIPTION
The arguments to path.relative were in the wrong order and the regex was compensating for it.  This fixes #1469, where grunt.file.delete incorrectly reported the path as outside the current directory.