### PR TITLE
Removing duplicate BOM strip code

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -227,10 +227,6 @@ file.read = function(filepath, options) {
     // string. If no encoding was specified, use the default.
     if (options.encoding !== null) {
       contents = iconv.decode(contents, options.encoding || file.defaultEncoding, {stripBOM: !file.preserveBOM});
-      // Strip any BOM that might exist.
-      if (!file.preserveBOM && contents.charCodeAt(0) === 0xFEFF) {
-        contents = contents.substring(1);
-      }
     }
     grunt.verbose.ok();
     return contents;


### PR DESCRIPTION
Since iconv.decode() handles removing or preserving the BOM (according to the option given), the additional code to strip any BOM that might exist is unnecessary.

Removing this duplicate code for cleanliness/DRYness.
