### PR TITLE
Ensure a grunt bin gets created upon install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "test-tap": "grunt test:tap"
   },
   "main": "lib/grunt",
+  "bin": {
+    "grunt": "node_modules/grunt-cli/bin/grunt"
+  },
   "keywords": [
     "task",
     "async",


### PR DESCRIPTION
This is a fix as just installing `grunt-cli` as a dependency doesn't actually create the appropriate binary as reported by @vladikoff.

@vladikoff could you please review? Thanks!

```shell
npm i gruntjs/grunt#fix-cli-bin
./node_modules/.bin/grunt
```