### PR TITLE
Use grunt-known-options for shared options between Grunt and grunt-cli

### DIFF
--- a/lib/grunt/cli.js
+++ b/lib/grunt/cli.js
@@ -2,11 +2,9 @@
 
 var grunt = require('../grunt');
 
-// Nodejs libs.
-var path = require('path');
-
 // External libs.
 var nopt = require('nopt');
+var gruntOptions = require('grunt-known-options');
 
 // This is only executed when run via command line.
 var cli = module.exports = function(options, done) {
@@ -30,71 +28,7 @@ var cli = module.exports = function(options, done) {
 };
 
 // Default options.
-var optlist = cli.optlist = {
-  help: {
-    short: 'h',
-    info: 'Display this help text.',
-    type: Boolean
-  },
-  base: {
-    info: 'Specify an alternate base path. By default, all file paths are relative to the Gruntfile. ' +
-          '(grunt.file.setBase) *',
-    type: path
-  },
-  color: {
-    info: 'Disable colored output.',
-    type: Boolean,
-    negate: true
-  },
-  gruntfile: {
-    info: 'Specify an alternate Gruntfile. By default, grunt looks in the current or parent directories ' +
-          'for the nearest Gruntfile.js or Gruntfile.coffee file.',
-    type: path
-  },
-  debug: {
-    short: 'd',
-    info: 'Enable debugging mode for tasks that support it.',
-    type: [Number, Boolean]
-  },
-  stack: {
-    info: 'Print a stack trace when exiting with a warning or fatal error.',
-    type: Boolean
-  },
-  force: {
-    short: 'f',
-    info: 'A way to force your way past warnings. Want a suggestion? Don\'t use this option, fix your code.',
-    type: Boolean
-  },
-  tasks: {
-    info: 'Additional directory paths to scan for task and "extra" files. (grunt.loadTasks) *',
-    type: Array
-  },
-  npm: {
-    info: 'Npm-installed grunt plugins to scan for task and "extra" files. (grunt.loadNpmTasks) *',
-    type: Array
-  },
-  write: {
-    info: 'Disable writing files (dry run).',
-    type: Boolean,
-    negate: true
-  },
-  verbose: {
-    short: 'v',
-    info: 'Verbose mode. A lot more information output.',
-    type: Boolean
-  },
-  version: {
-    short: 'V',
-    info: 'Print the grunt version. Combine with --verbose for more info.',
-    type: Boolean
-  },
-  // Even though shell auto-completion is now handled by grunt-cli, leave this
-  // option here for display in the --help screen.
-  completion: {
-    info: 'Output shell auto-completion rules. See the grunt-cli documentation for more information.',
-    type: String
-  },
-};
+var optlist = cli.optlist = gruntOptions;
 
 // Parse `optlist` into a form that nopt can handle.
 var aliases = {};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "findup-sync": "~0.3.0",
     "glob": "~7.0.0",
     "grunt-cli": "1.0.0-rc1",
-    "grunt-known-options": "~1.0.0",
+    "grunt-known-options": "~1.1.0",
     "grunt-legacy-log": "1.0.0-rc1",
     "grunt-legacy-util": "1.0.0-rc1",
     "iconv-lite": "~0.4.13",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "findup-sync": "~0.3.0",
     "glob": "~7.0.0",
     "grunt-cli": "1.0.0-rc1",
+    "grunt-known-options": "~1.0.0",
     "grunt-legacy-log": "1.0.0-rc1",
     "grunt-legacy-util": "1.0.0-rc1",
     "iconv-lite": "~0.4.13",


### PR DESCRIPTION
Ref gruntjs/grunt-cli#102

Uses the newly created https://github.com/gruntjs/grunt-known-options to share the known Grunt options between grunt and grunt-cli.