### PR TITLE
Use local bin that points to grunt-cli

### DIFF
--- a/bin/grunt
+++ b/bin/grunt
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('grunt-cli/bin/grunt');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "lib/grunt",
   "bin": {
-    "grunt": "node_modules/grunt-cli/bin/grunt"
+    "grunt": "bin/grunt"
   },
   "keywords": [
     "task",
@@ -43,7 +43,7 @@
     "exit": "~0.1.1",
     "findup-sync": "~0.3.0",
     "glob": "~7.0.0",
-    "grunt-cli": "1.2.0",
+    "grunt-cli": "~1.2.0",
     "grunt-known-options": "~1.1.0",
     "grunt-legacy-log": "~1.0.0",
     "grunt-legacy-util": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "through2": "~2.0.0"
   },
   "files": [
-    "lib"
+    "lib",
+    "bin"
   ]
 }


### PR DESCRIPTION
Fixes GH-1499

This fixes the issue where `grunt-cli` might not yet exist when npm is trying to create a binary.

@vladikoff Mind giving this a full vetting? I tested on `npm@2` and `npm@3` but want to make sure I'm not missing something big with this. Thanks!