### PR TITLE
Fix developer npm install with Grunt trying to be a dependency of itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,5 @@ node_js:
   - "iojs"
 before_install:
   - npm install -g npm
-before_script:
-  - npm uninstall grunt # https://github.com/npm/npm/issues/3958
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "difflet": "~0.2.3",
-    "grunt": "gruntjs/grunt",
+    "grunt": "./",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-nodeunit": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -56,9 +56,10 @@
   },
   "devDependencies": {
     "difflet": "~0.2.3",
-    "grunt-contrib-jshint": "~1.0.0",
-    "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt-contrib-watch": "~1.0.0",
+    "grunt": "gruntjs/grunt",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-contrib-watch": "^1.0.0",
     "grunt-jscs": "~2.8.0",
     "semver": "2.1.0",
     "shelljs": "~0.5.3",


### PR DESCRIPTION
Installing the devDeps currently fails as the grunt plugins have `"grunt": ">=0.4.0"` as a peer dep. npm@2 wants the peer dep installed but can't because grunt can't install a dependency to itself.

This uses npm's ability to install from a local folder to install grunt and get around the peer dep issue.

- [ ] review @vladikoff