### PR TITLE
Fix race condition in mkdir

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -187,10 +187,10 @@ file.mkdir = function(dirpath, mode) {
   dirpath.split(pathSeparatorRe).reduce(function(parts, part) {
     parts += part + '/';
     var subpath = path.resolve(parts);
-    if (!file.exists(subpath)) {
-      try {
-        fs.mkdirSync(subpath, mode);
-      } catch (e) {
+    try {
+      fs.mkdirSync(subpath, mode);
+    } catch (e) {
+      if (e.code !== 'EEXIST') {
         throw grunt.util.error('Unable to create directory "' + subpath + '" (Error code: ' + e.code + ').', e);
       }
     }


### PR DESCRIPTION
I sometimes get errors like

```
Warning: Unable to create directory "/mnt/jenkins/workspace/main/master/mesh-service/cake/app/webroot/js/app/view/angular/templates/compiled" (Error code: EEXIST).
```

This would happen if two process called this at the same time. This change makes the function behave more like `mkdir -p`, which wouldn't fail in this situation. Plus, this change reduces the number of file operations.

---

(FYI, I just bit off a little with this pull request. There's more wrong with this function. For example I noticed that unlike `mkdir -p`, it succeeds if there is already a file -- not a directory -- present. You may want to consider looking at [mkdirp](https://www.npmjs.com/package/mkdirp).)
