### PR TITLE
Small usability idea/fix - err highlighting

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -39,6 +39,7 @@ function dumpStack(e) {
       console.log(e.stack);
     }
   }
+  grunt.log.warn('Tip:').log(' Add --stack option for detailed error messages.').writeLn();
 }
 
 // A fatal error occurred. Abort immediately.
@@ -60,7 +61,8 @@ fail.warn = function(e, errcode) {
   // If -f or --force aren't used, stop script processing.
   if (!grunt.option('force')) {
     dumpStack(e);
-    grunt.log.writeln().fail('Aborted due to warnings.');
+    grunt.log.writeln().error('Aborted due to').warn('warnings.');
+    grunt.log.writeln().error('Fatal: Task Aborted.');
     grunt.util.exit(typeof errcode === 'number' ? errcode : fail.code.WARNING);
   }
 };


### PR DESCRIPTION
> I had issues getting the CLA signing to link to the right email address. Wanted to try replacing the PR 

> Parent #1563

Some of the people on my team were getting confused by the color of messages in console (regarding the importance of error vs. warning.)

I am just guessing this patch makes it more clear, but not really sure.

I wanted to see if anyone had feedback for this small change.

Thanks in advance.