### PR TITLE
Small usability idea/fix - err highlighting

### DIFF
--- a/lib/grunt/fail.js
+++ b/lib/grunt/fail.js
@@ -60,7 +60,7 @@ fail.warn = function(e, errcode) {
   // If -f or --force aren't used, stop script processing.
   if (!grunt.option('force')) {
     dumpStack(e);
-    grunt.log.writeln().fail('Aborted due to warnings.');
+    grunt.log.writeln().fail('Aborted due to ').warn('warnings.');
     grunt.util.exit(typeof errcode === 'number' ? errcode : fail.code.WARNING);
   }
 };


### PR DESCRIPTION
Some of the people on my team were getting confused by the color of messages in console (regarding the importance of error vs. warning.)

I am hoping this patch makes it more clear, but any input is appreciated.

Thanks in advance.

> NB: This is a dup/related to #1563  - ONLY BECAUSE CLA signing wouldn't work.