### PR TITLE
Make 'task.loadNpmTasks' can load npm tasks from up folder with 5 times.

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -367,9 +367,17 @@ task.loadTasks = function(tasksdir) {
 
 // Load tasks and handlers from a given locally-installed Npm module (installed
 // relative to the base dir).
-task.loadNpmTasks = function(name) {
+task.loadNpmTasks = function(name, root, retryNum) {
   loadTasksMessage('"' + name + '" local Npm module');
-  var root = path.resolve('node_modules');
+
+  root = (!root || Number.isInteger(root) /* Make compatible with "load-grunt-tasks" which from https://github.com/sindresorhus/load-grunt-tasks */ ) ?
+    path.resolve('node_modules') :			  // current projcet path
+    root;													        // current projcet's parent path
+
+  retryNum = (typeof retryNum == 'undefined' || isNaN(retryNum) /* Make compatible with "load-grunt-tasks" which from https://github.com/sindresorhus/load-grunt-tasks */ ) ?
+    5 :                                                         // default retry count
+    retryNum;                                                   // left retry count
+
   var pkgfile = path.join(root, name, 'package.json');
   var pkg = grunt.file.exists(pkgfile) ? grunt.file.readJSON(pkgfile) : {keywords: []};
 
@@ -396,9 +404,14 @@ task.loadNpmTasks = function(name) {
   var tasksdir = path.join(root, name, 'tasks');
   if (grunt.file.exists(tasksdir)) {
     loadTasks(tasksdir);
+  } else if (retryNum-- > 0){
+
+    // Search it from up
+    task.loadNpmTasks( name, path.join(root, '..', '..', 'node_modules'), retryNum );
   } else {
     grunt.log.error('Local Npm module "' + name + '" not found. Is it installed?');
   }
+  
 };
 
 // Initialize tasks.


### PR DESCRIPTION
This code can work on many projects they have common grunt plugins. It don't only search grunt plugins on current path, and support to seach grunt plugins up folder at most 5 times.