### PR TITLE
FEATURE - Expose Grunt Option Keys for Ease of Use

### DIFF
--- a/lib/grunt/option.js
+++ b/lib/grunt/option.js
@@ -31,3 +31,8 @@ option.flags = function() {
       (typeof val === 'boolean' ? '' : '=' + val);
   });
 };
+
+// Get all option keys
+option.keys = function() {
+  return Object.keys(data);
+};

--- a/test/grunt/option_test.js
+++ b/test/grunt/option_test.js
@@ -38,4 +38,15 @@ exports.option = {
     test.deepEqual(grunt.option.flags(), ['--foo=bar', '--there', '--obj=[object Object]']);
     test.done();
   },
+  'option.keys': function(test) {
+    test.expect(1);
+    grunt.option.init({
+      foo: 'bar',
+      there: true,
+      obj: {foo: 'bar'},
+      arr: []
+    });
+    test.deepEqual(grunt.option.keys(), ['foo', 'there', 'obj', 'arr']);
+    test.done();
+  }
 };


### PR DESCRIPTION
Expose grunt option keys for use with grunt tasks

Example use case : saving all current options to json, for developer preferences

grunt.registerTask('gen', 'Generate based on last settings', function () {
    // TODO
});
