### PR TITLE
Provide correct git repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.1",
   "author": "Grunt Development Team (http://gruntjs.com/development-team)",
   "homepage": "http://gruntjs.com/",
-  "repository": "gruntjs/grunt",
+  "repository": "https://github.com/gruntjs/grunt.git",
   "license": "MIT",
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
I have noticed that package.json for gruntjs doesn't provide correct git repository url and that is why I have fixed it providing https://github.com/gruntjs/grunt.git instead of gruntjs/grunt.
I have validated it by [package.json validator](http://package-json-validator.com/) and the screenshot is attached.

![gruntjsjsonerror](https://cloud.githubusercontent.com/assets/13225708/22228643/8539ee2e-e1a0-11e6-810c-21885b86602e.png)
