### PR TITLE
add files `pattern` check

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -43,6 +43,8 @@ var processPatterns = function(patterns, fn) {
   var result = [];
   // Iterate over flattened patterns array.
   grunt.util._.flattenDeep(patterns).forEach(function(pattern) {
+    // If pattern is string, skip
+    if (typeof pattern !== 'string') { return; }
     // If the first character is ! it should be omitted
     var exclusion = pattern.indexOf('!') === 0;
     // If the pattern is an exclusion, remove the !


### PR DESCRIPTION
See issue: https://github.com/webpack-contrib/grunt-webpack/issues/122

In `grunt-webpack` with multiple-compiler situation, the webpack config array is passed to target, which makes `pattern` is an Array with webpack config Objects instead of file pattern strings.