### PR TITLE
Add Node.js v7 and v8 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ node_js:
   - "4.2"
   - "5"
   - "6"
+  - "7"
+  - "8"
   - "iojs"
 before_install:
   - npm install -g npm


### PR DESCRIPTION
Add support for Node.js v7 and v8.
Updated .travis.yml.
