### PR TITLE
Use SOURCE_DATE_EPOCH to render dates in template.

### DIFF
--- a/lib/grunt/template.js
+++ b/lib/grunt/template.js
@@ -10,7 +10,11 @@ template.date = require('dateformat');
 
 // Format today's date.
 template.today = function(format) {
-  return template.date(new Date(), format);
+  var now = new Date();
+  if (process.env.SOURCE_DATE_EPOCH) {
+    now = new Date((process.env.SOURCE_DATE_EPOCH * 1000) + (now.getTimezoneOffset() * 60000));
+  }
+  return template.date(now, format);
 };
 
 // Template delimiters.


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that grunt can generate non-reproducible output. This is affecting the
reproducibility status other packages (such as jquery-tablesorter) that
set a "pkg.banner" such as:

   <%= grunt.template.today("mm-dd-yyyy")

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>