### PR TITLE
Remove deprecation warning (pins coffee-script dep at 1.12.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "difflet": "~1.0.1",
-    "eslint-config-grunt": "~1.0.1",or 
+    "eslint-config-grunt": "~1.0.1",
     "grunt-contrib-nodeunit": "~1.0.0",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-eslint": "~18.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tool"
   ],
   "dependencies": {
-    "coffee-script": "~1.10.0",
+    "coffee-script": "1.12.6",
     "dateformat": "~1.0.12",
     "eventemitter2": "~0.4.13",
     "exit": "~0.1.1",
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "difflet": "~1.0.1",
-    "eslint-config-grunt": "~1.0.1",
+    "eslint-config-grunt": "~1.0.1",or 
     "grunt-contrib-nodeunit": "~1.0.0",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-eslint": "~18.1.0",


### PR DESCRIPTION
For more information, see:

• https://github.com/gruntjs/grunt/issues/1556#issuecomment-315189532 
• https://github.com/jashkenas/coffeescript/pull/4543
• https://github.com/jashkenas/coffeescript/commit/f661f91323e4873bc581e98f5bec105f53c372b3