### PR TITLE
Paraquire - paranoidal require

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -14,7 +14,14 @@ function gRequire(name) {
   return grunt[name] = require('./grunt/' + name);
 }
 
-var util = require('grunt-legacy-util');
+var paraquire = require('paraquire')(module);
+
+var util = paraquire('grunt-legacy-util', {
+  builtin: ['child_process'],
+  Buffer: true,
+  process: ['argv', 'execArgv', 'execPath', 'exit', 'platform', 'stderr', 'stdout'],
+  'process.env': ['OSTYPE'],
+});
 grunt.util = util;
 grunt.util.task = require('./util/task');
 

--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -25,7 +25,11 @@ var util = paraquire('grunt-legacy-util', {
 grunt.util = util;
 grunt.util.task = require('./util/task');
 
-var Log = require('grunt-legacy-log').Log;
+var Log = paraquire('grunt-legacy-log', {
+  builtin: ['util'],
+  process: ['argv', 'stderr', 'stdout'],
+  'process.env': ['COLORTERM'],
+}).Log;
 var log = new Log({grunt: grunt});
 grunt.log = log;
 

--- a/lib/grunt/event.js
+++ b/lib/grunt/event.js
@@ -1,7 +1,9 @@
 'use strict';
 
 // External lib.
-var EventEmitter2 = require('eventemitter2').EventEmitter2;
+var paraquire = require('paraquire')(module);
+
+var EventEmitter2 = paraquire('eventemitter2').EventEmitter2;
 
 // Awesome.
 module.exports = new EventEmitter2({wildcard: true});

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -15,7 +15,7 @@ var paraquire = require('paraquire')(module);
 file.glob = require('glob');
 file.minimatch = require('minimatch');
 file.findup = require('findup-sync');
-var YAML = require('js-yaml');
+var YAML = paraquire('js-yaml');
 var rimraf = require('rimraf');
 var iconv = paraquire('iconv-lite', {
   builtinErrors: true,

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -22,7 +22,9 @@ var iconv = paraquire('iconv-lite', {
   builtin: ['buffer', 'string_decoder', 'util'],
   globals_s: true,
 });
-var pathIsAbsolute = require('path-is-absolute');
+var pathIsAbsolute = paraquire('path-is-absolute', {
+  process: ['platform'],
+});
 
 // Windows?
 var win32 = process.platform === 'win32';

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -18,7 +18,10 @@ file.glob = paraquire('glob', {
   'process.env': ['NODE_DEBUG'],
 });
 file.minimatch = paraquire('minimatch');
-file.findup = require('findup-sync');
+file.findup = paraquire('findup-sync', {
+  builtin: ['assert', 'events', 'fs', 'path'],
+  process: ['cwd', 'platform', 'version'],
+});
 var YAML = paraquire('js-yaml');
 var rimraf = require('rimraf');
 var iconv = paraquire('iconv-lite', {

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -10,12 +10,18 @@ var path = require('path');
 var file = module.exports = {};
 
 // External libs.
+var paraquire = require('paraquire')(module);
+
 file.glob = require('glob');
 file.minimatch = require('minimatch');
 file.findup = require('findup-sync');
 var YAML = require('js-yaml');
 var rimraf = require('rimraf');
-var iconv = require('iconv-lite');
+var iconv = paraquire('iconv-lite', {
+  builtinErrors: true,
+  builtin: ['buffer', 'string_decoder', 'util'],
+  globals_s: true,
+});
 var pathIsAbsolute = require('path-is-absolute');
 
 // Windows?

--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -12,8 +12,12 @@ var file = module.exports = {};
 // External libs.
 var paraquire = require('paraquire')(module);
 
-file.glob = require('glob');
-file.minimatch = require('minimatch');
+file.glob = paraquire('glob', {
+  builtin: ['assert', 'events', 'fs', 'path'],
+  process: ['cwd', 'version'],
+  'process.env': ['NODE_DEBUG'],
+});
+file.minimatch = paraquire('minimatch');
 file.findup = require('findup-sync');
 var YAML = paraquire('js-yaml');
 var rimraf = require('rimraf');

--- a/lib/grunt/template.js
+++ b/lib/grunt/template.js
@@ -6,7 +6,9 @@ var grunt = require('../grunt');
 var template = module.exports = {};
 
 // External libs.
-template.date = require('dateformat');
+var paraquire = require('paraquire')(module);
+
+template.date = paraquire('dateformat');
 
 // Format today's date.
 template.today = function(format) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "js-yaml": "~3.5.2",
     "minimatch": "~3.0.2",
     "nopt": "~3.0.6",
+    "paraquire": "^1.3.1",
     "path-is-absolute": "~1.0.0",
     "rimraf": "~2.2.8"
   },


### PR DESCRIPTION
I'm at hard work on [`paraquire`](https://github.com/nickkolok/paraquire) - security-oriented `require` alternative and I invite you to join.
This PR adds security jails to most libraries used in `grunt`; unfortunately, I haven't managed to give correct permissions to some of them, so they remain usually `require`d.

I know about CLA but it is needed only if you agree to work in this direction. Then I will sign CLA and send it to you.