### PR TITLE
Use mkdirp for file.mkdir

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -17,6 +17,7 @@ var YAML = require('js-yaml');
 var rimraf = require('rimraf');
 var iconv = require('iconv-lite');
 var pathIsAbsolute = require('path-is-absolute');
+var mkdirp = require('mkdirp').sync;
 
 // Windows?
 var win32 = process.platform === 'win32';
@@ -180,22 +181,11 @@ file.expandMapping = function(patterns, destBase, options) {
 // Like mkdir -p. Create a directory and any intermediary directories.
 file.mkdir = function(dirpath, mode) {
   if (grunt.option('no-write')) { return; }
-  // Set directory mode in a strict-mode-friendly way.
-  if (mode == null) {
-    mode = parseInt('0777', 8) & (~process.umask());
+  try {
+    mkdirp(dirpath, { mode: mode });
+  } catch (e) {
+    throw grunt.util.error('Unable to create directory "' + dirpath + '" (Error code: ' + e.code + ').', e);
   }
-  dirpath.split(pathSeparatorRe).reduce(function(parts, part) {
-    parts += part + '/';
-    var subpath = path.resolve(parts);
-    if (!file.exists(subpath)) {
-      try {
-        fs.mkdirSync(subpath, mode);
-      } catch (e) {
-        throw grunt.util.error('Unable to create directory "' + subpath + '" (Error code: ' + e.code + ').', e);
-      }
-    }
-    return parts;
-  }, '');
 };
 
 // Recurse into a directory, executing callback for each file.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "iconv-lite": "~0.4.13",
     "js-yaml": "~3.5.2",
     "minimatch": "~3.0.2",
+    "mkdirp": "~0.5.1",
     "nopt": "~3.0.6",
     "path-is-absolute": "~1.0.0",
     "rimraf": "~2.2.8"


### PR DESCRIPTION
Fixes GH-1511
Fixes GH-1351

This uses the well vetted [mkdirp](https://www.npmjs.com/package/mkdirp) module within `file.mkdir` which fixes some bugs people are running into in the above two issues.