### PR TITLE
Bump minimatch to 3.0.4 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-legacy-util": "~1.1.1",
     "iconv-lite": "~0.4.13",
     "js-yaml": "~3.5.2",
-    "minimatch": "~3.0.2",
+    "minimatch": "^3.0.4",
     "mkdirp": "~0.5.1",
     "nopt": "~3.0.6",
     "path-is-absolute": "~1.0.0",


### PR DESCRIPTION
Fix npm audit warning:
                   
  Moderate        ReDoS
  Package         brace-expansion
  Dependency of   grunt [dev]
  Path            grunt > minimatch > brace-expansion
  More info       https://nodesecurity.io/advisories/338 

It seems the ~ syntax is expanded by npm to newer versions automatically,
even on clean installs. However, it can be worked around by specifying
a newer version of minimatch directly in the project that uses grunt, because
the range does allow deduplication. Anyhow, let's fix this on the grunt side
instead.