### PR TITLE
Remove coffeescript from dependencies.

### DIFF
--- a/lib/grunt.js
+++ b/lib/grunt.js
@@ -4,7 +4,25 @@
 var path = require('path');
 
 // This allows grunt to require() .coffee files.
-require('coffeescript/register');
+try {
+  // Note: grunt no longer depends on CoffeeScript, it will only use it if it is intentionally
+  // installed in the project.
+  require('coffeescript/register');
+} catch (e) {
+  // This is fine, and will cause no problems so long as the user doesn't load .coffee files.
+  // Print a useful error if we attempt to load a .coffee file.
+  if (require.extensions) {
+    var FILE_EXTENSIONS = ['.coffee', '.litcoffee', '.coffee.md'];
+    for (var i = 0; i < FILE_EXTENSIONS.length; i++) {
+      require.extensions[FILE_EXTENSIONS[i]] = function() {
+        throw new Error(
+          'Grunt attempted to load a .coffee file but CoffeeScript was not installed.\n' +
+          'Please run `npm install --dev coffeescript` to enable loading CoffeeScript.'
+        );
+      };
+    }
+  }
+}
 
 // The module to be exported.
 var grunt = module.exports = {};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "tool"
   ],
   "dependencies": {
-    "coffeescript": "~1.10.0",
     "dateformat": "~1.0.12",
     "eventemitter2": "~0.4.13",
     "exit": "~0.1.1",


### PR DESCRIPTION
https://github.com/gruntjs/grunt-cli/pull/117 removes the need for coffeescript in grunt by using Liftoff instead.

To ease transition, if `coffeescript` is still around, Grunt will attempt to load it. If it is not, and the user loads a CoffeeScript file, Grunt will print a useful error indicating that the `coffeescript` package should be installed as a dev dependency.

This is considerably more user-friendly than dropping the `require` entirely, but doing so is feasible with the latest `grunt-cli` as users may simply use `grunt --require coffeescript/register`.