### PR TITLE
Avoiding infinite loop on very long command names.

### DIFF
--- a/lib/grunt/help.js
+++ b/lib/grunt/help.js
@@ -12,7 +12,8 @@ exports.initCol1 = function(str) {
 };
 exports.initWidths = function() {
   // Widths for options/tasks table output.
-  exports.widths = [1, col1len, 2, 76 - col1len];
+  var commandWidth = Math.max(col1len + 20, 76);
+  exports.widths = [1, col1len, 2, commandWidth - col1len];
 };
 
 // Render an array in table form.


### PR DESCRIPTION
If very long command names are registered, grunt --help runs
out of memory trying to generate the help table. This commit
adjusts the width to be at least 20 longer than the maximal
command length.

Fixes #1696