### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v1.1.0
+  date: 2020-03-16
+  changes:
+    - Update to mkdirp ~1.0.3
+    - Only support versions of Node >= 8
 v1.0.4
   date: 2019-04-22
   changes:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt",
   "description": "The JavaScript Task Runner",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "author": "Grunt Development Team (https://gruntjs.com/development-team)",
   "homepage": "https://gruntjs.com/",
   "repository": "https://github.com/gruntjs/grunt.git",


### PR DESCRIPTION
@shama is 1.1.0 okay due to mkdirp update ? or should we just bump to 1.0.5?