### PR TITLE
Switch to use `safeLoad` for loading YML files via `file.readYAML`.

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -241,12 +241,21 @@ file.readJSON = function(filepath, options) {
 };
 
 // Read a YAML file, parse its contents, return an object.
-file.readYAML = function(filepath, options) {
+file.readYAML = function(filepath, options, yamlOptions) {
+  if (!options) { options = {}; }
+  if (!yamlOptions) { yamlOptions = {}; }
+
   var src = file.read(filepath, options);
   var result;
   grunt.verbose.write('Parsing ' + filepath + '...');
   try {
-    result = YAML.load(src);
+    // use the recommended way of reading YAML files
+    // https://github.com/nodeca/js-yaml#safeload-string---options-
+    if (yamlOptions.unsafeLoad) {
+      result = YAML.load(src);
+    } else {
+      result = YAML.safeLoad(src);
+    }
     grunt.verbose.ok();
     return result;
   } catch (e) {

--- a/test/grunt/file_test.js
+++ b/test/grunt/file_test.js
@@ -452,10 +452,13 @@ exports.file = {
     test.done();
   },
   'readYAML': function(test) {
-    test.expect(4);
+    test.expect(5);
     var obj;
     obj = grunt.file.readYAML('test/fixtures/utf8.yaml');
-    test.deepEqual(obj, this.object, 'file should be read as utf8 by default and parsed correctly.');
+    test.deepEqual(obj, this.object, 'file should be safely read as utf8 by default and parsed correctly.');
+
+    obj = grunt.file.readYAML('test/fixtures/utf8.yaml', null, {unsafeLoad: true});
+    test.deepEqual(obj, this.object, 'file should be unsafely read as utf8 by default and parsed correctly.');
 
     obj = grunt.file.readYAML('test/fixtures/iso-8859-1.yaml', {encoding: 'iso-8859-1'});
     test.deepEqual(obj, this.object, 'file should be read using the specified encoding.');


### PR DESCRIPTION
For previous behaviour please use the following:

```
readYAML('test/fixtures/utf8.yaml', null, {unsafeLoad: true});
```

@shama got a sec for an r? 👀 