### PR TITLE
support .cjs extension

### DIFF
--- a/lib/grunt/task.js
+++ b/lib/grunt/task.js
@@ -345,7 +345,7 @@ function loadTasksMessage(info) {
 // Load tasks and handlers from a given directory.
 function loadTasks(tasksdir) {
   try {
-    var files = grunt.file.glob.sync('*.{js,coffee}', {cwd: tasksdir, maxDepth: 1});
+    var files = grunt.file.glob.sync('*.{js,cjs,coffee}', {cwd: tasksdir, maxDepth: 1});
     // Load tasks from files.
     files.forEach(function(filename) {
       loadTask(path.join(tasksdir, filename));
@@ -434,7 +434,7 @@ task.init = function(tasks, options) {
     gruntfile = null;
   } else {
     gruntfile = grunt.option('gruntfile') ||
-      grunt.file.findup('Gruntfile.{js,coffee}', {nocase: true});
+      grunt.file.findup('Gruntfile.{js,cjs,coffee}', {nocase: true});
     msg = 'Reading "' + (gruntfile ? path.basename(gruntfile) : '???') + '" Gruntfile...';
   }
 


### PR DESCRIPTION
In projects configured for ES modules (`"type": "module"` set in `package.json`),
in order to leave all Grunt-related scripts CommonJS-based, those files need to have the `.cjs` extension to still work.

This pull request makes Grunt accept `.cjs` files just like `.js` files for both `Gruntfile.(c)js` lookup and `grunt.loadTasks()`.
