### PR TITLE
Upgraded Minimatch annd glob version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "eventemitter2": "~0.4.13",
     "exit": "~0.1.2",
     "findup-sync": "~5.0.0",
-    "glob": "~7.1.6",
+    "glob": "~7.2.0",
     "grunt-cli": "~1.4.3",
     "grunt-known-options": "~2.0.0",
     "grunt-legacy-log": "~3.0.0",
     "grunt-legacy-util": "~2.0.1",
     "iconv-lite": "~0.6.3",
     "js-yaml": "~3.14.0",
-    "minimatch": "~3.0.4",
+    "minimatch": "~9.0.3",
     "nopt": "~3.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello, Npm Audit is flagging minimatch version < 3.0.4. This PR has the upgraded dependency.