### PR TITLE
Fixed Issue #1764

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -268,7 +268,9 @@ file.write = function(filepath, contents, options) {
   var nowrite = grunt.option('no-write');
   grunt.verbose.write((nowrite ? 'Not actually writing ' : 'Writing ') + filepath + '...');
   // Create path, if necessary.
-  file.mkdir(path.dirname(filepath));
+  if (!file.exists(path.dirname(filepath))) {
+    file.mkdir(path.dirname(filepath));
+  }
   try {
     // If contents is already a Buffer, don't try to encode it. If no encoding
     // was specified, use the default.


### PR DESCRIPTION
The file.mkdir function is trying to create a directory that already exists, which causing the EXIST error. 
This function is not checking  whether if the directory exists before trying to create it.

So i Go through lot of time before finding a solution with a simple logic, I added a  check before calling file.mkdir function

`if (!file.exists(path.dirname(filepath))) {
  file.mkdir(path.dirname(filepath));
}`

It first checks if the directory exists using the file.exists function. If the directory does not exist, then it creates the directory using the file.mkdir function. 

Thanks for Raising this Issue 
Looking Forward to Help out more :)

Fixes https://github.com/gruntjs/grunt/issues/1764.