### PR TITLE
Update from nopt 3.x to nopt 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
     "exit": "~0.1.2",
     "findup-sync": "~5.0.0",
     "glob": "~7.1.6",
-    "grunt-cli": "~1.4.3",
+    "grunt-cli": "^1.4.3",
     "grunt-known-options": "~2.0.0",
     "grunt-legacy-log": "~3.0.0",
     "grunt-legacy-util": "~2.0.1",
     "iconv-lite": "~0.6.3",
     "js-yaml": "~3.14.0",
     "minimatch": "~3.0.4",
-    "nopt": "~3.0.6"
+    "nopt": "^5.0.0"
   },
   "devDependencies": {
     "difflet": "~1.0.1",


### PR DESCRIPTION
* grunt-cli updated to nopt 4.x in https://github.com/gruntjs/grunt-cli/pull/117
* grunt-cli updated to nopt 5.0 in https://github.com/gruntjs/grunt-cli/pull/156
* changelog: https://github.com/npm/nopt/blob/v5.0.0/CHANGELOG.md

The simple usage of `nopt(known, alias, argv, 2)` has remained unchanged through both changes, same as in this repo.

Installation of latest grunt- produces a warning:

> npm WARN deprecated osenv@0.1.5: This package is no longer supported.

This package was used by nopt to call `os.homedir()` which has been built-in since Node.js 2. The dependency was removed in nopt 5.0.0 with https://github.com/npm/nopt/commit/5c0e45b2f94414c074270b133e90c77ec35f5a4b.

Newer versions of nopt are available, but those raise the required Node.js engine level. In order to make this safe to land, and easy to release, resolve the warning first by moving to nopt 5.0.0, matching grunt-cli.

I'm loosening grunt-cli to allow for grunt-cli 1.5.0, which was just released with a similar fix. This way it will update by default, but not cause duplicate installations for downstream projects that depend on grunt-cli 1.4 directly.