### PR TITLE
CI: add Node.js 24 to version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 20, 22]
+        node: [16, 18, 20, 22, 24]
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
Add Node.js 24 to version matrix. It is the next LTS version.