### PR TITLE
Fix date template with default export

### DIFF
--- a/lib/grunt/template.js
+++ b/lib/grunt/template.js
@@ -6,7 +6,7 @@ var grunt = require('../grunt');
 var template = module.exports = {};
 
 // External libs.
-template.date = require('dateformat');
+template.date = require('dateformat').default;
 
 // Format today's date.
 template.today = function(format) {


### PR DESCRIPTION
There seems to be a change to the datetime module which now has a default export. This was breaking `template.today`