### PR TITLE
Fix typo "coping" → "copying" in file.js comment

### DIFF
--- a/lib/grunt/file.js
+++ b/lib/grunt/file.js
@@ -290,7 +290,7 @@ file.write = function(filepath, contents, options) {
 // Read a file, optionally processing its content, then write the output.
 // Or read a directory, recursively creating directories, reading files,
 // processing content, writing output.
-// Handles symlinks by coping them as files or directories.
+// Handles symlinks by copying them as files or directories.
 file.copy = function copy(srcpath, destpath, options) {
   if (file.isLink(srcpath)) {
     file._copySymbolicLink(srcpath, destpath);


### PR DESCRIPTION

**Repo:** gruntjs/grunt (⭐ 12000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Corrects a small typo in the doc comment above `file.copy` in `lib/grunt/file.js`. The word "coping" should be "copying" — the comment describes how symlinks are handled when copying files/directories.

## Why
Improves comment clarity and accuracy for future readers and contributors. The function copies symlinks; "coping" is unrelated and reads as a mistake. Found via a `codespell`-style scan of the repo.

## Testing
Comment-only change — no behavior is affected. `git diff` confirms the only modification is the single word in a comment. No tests need updating.

## Risk
Low — comment-only change with no runtime effect.
