### PR TITLE
Update js-yaml to 3.15.0 to fix CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-legacy-log": "~3.0.0",
     "grunt-legacy-util": "~2.0.1",
     "iconv-lite": "~0.6.3",
-    "js-yaml": "~3.14.0",
+    "js-yaml": "~3.15.0",
     "minimatch": "^3.1.5",
     "nopt": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-legacy-log": "~3.0.0",
     "grunt-legacy-util": "~2.0.1",
     "iconv-lite": "~0.6.3",
-    "js-yaml": "~3.15.0",
+    "js-yaml": "^3.15.0",
     "minimatch": "^3.1.5",
     "nopt": "^5.0.0"
   },


### PR DESCRIPTION
This PR bumps vulnerable dependency `js-yaml` to resolve https://github.com/advisories/GHSA-h67p-54hq-rp68.